### PR TITLE
Add scratches xref table to intermediate models

### DIFF
--- a/models/analytics/intermediate/f_games_scratches.sql
+++ b/models/analytics/intermediate/f_games_scratches.sql
@@ -1,0 +1,33 @@
+with
+
+home_team_scratches as (
+    select
+        boxscore.game_id
+        , scratches as player_id
+    from {{ ref('stg_nhl__boxscore') }} as boxscore
+    , unnest(boxscore.home_team_scratches) as scratches
+)
+
+, away_team_scratches as (
+    select
+        boxscore.game_id
+        , scratches as player_id
+    from {{ ref('stg_nhl__boxscore') }} as boxscore
+    , unnest(boxscore.away_team_scratches) as scratches
+)
+
+, unioned as (
+    select
+        game_id
+        , player_id
+    from home_team_scratches
+
+    union all
+
+    select
+        game_id
+        , player_id
+    from away_team_scratches
+)
+
+select * from unioned

--- a/models/analytics/intermediate/f_games_scratches.yml
+++ b/models/analytics/intermediate/f_games_scratches.yml
@@ -1,0 +1,22 @@
+version: 2
+
+models:
+  - name: f_games_scratches
+    description: A table containing `game_id` and corresponding `player_id` of players who were scratched either due to injury or a coach's decision
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - game_id
+            - player_id
+    columns:
+      - name: game_id
+        description: |
+          Foreign key that maps to an NHL game
+          {{ doc("game_id_description") }}
+        tests:
+          - not_null
+
+      - name: player_id
+        description: Foreign key that maps to an NHL player
+        tests:
+          - not_null

--- a/models/staging/stg_nhl__boxscore.sql
+++ b/models/staging/stg_nhl__boxscore.sql
@@ -25,6 +25,7 @@ live_boxscore as (
         , teams.home.teamstats.teamskaterstats.takeaways as home_team_takeaways
         , teams.home.teamstats.teamskaterstats.giveaways as home_team_giveaways
         , teams.home.teamstats.teamskaterstats.hits as home_team_hits
+        , teams.home.scratches as home_team_scratches
 
         -- Away team stats
         , teams.away.team.name as away_team_name
@@ -37,6 +38,7 @@ live_boxscore as (
         , teams.away.teamstats.teamskaterstats.takeaways as away_team_takeaways
         , teams.away.teamstats.teamskaterstats.giveaways as away_team_giveaways
         , teams.away.teamstats.teamskaterstats.hits as away_team_hits
+        , teams.away.scratches as away_team_scratches
     from live_boxscore
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ rules = L001,L003,L004,L005,L006,L007,L008,L010,L011,L012,L014,L015,L017,L018,L0
 # L027 References should be qualified if select has more than one referenced table/view. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L027
 # L028 References should be consistent in statements with a single table. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L028
 # L030 Inconsistent capitalisation of function names, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L030
-# L035 Do not specify “else null” in a case when statement (redundant), sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L035
+# L035 Do not specify "else null" in a case when statement (redundant), sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L035
 # L036 Select targets should be on a new line unless there is only one select target, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L036
 # L037 Ambiguous ordering directions for columns in order by clause, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L037
 # L039 Unnecessary whitespace found, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L039


### PR DESCRIPTION
# Overview
- Gives reliable visibility into which players were scratched
- Closes #20 

![Screen Shot 2022-05-01 at 1 21 16 PM](https://user-images.githubusercontent.com/81283016/166163228-6e6070ed-54ce-4a1f-b7a2-9e9dc80f9d26.png)


# Changes
- Add scratches field to `stg_nhl__boxscore`
- Add `f_games_player_scratches` intermediate model

# Other notes
- _Any other things that the reviewer should know about_

# Checks
- [x] All models ran successfully
- [x] Changes to models are reflected in the schema.yml
Pick one:
- [x] No test failures OR
- [x] No new test failures, and there is a plan in place to address existing ones
