### PR TITLE
Fix how duplicates are handled with more years of added data

### DIFF
--- a/macros/dedupe.sql
+++ b/macros/dedupe.sql
@@ -1,0 +1,22 @@
+{%- macro dedupe(model, key_fields, sort_fields=[], field_list=['*'], filter_list=[]) -%}
+{#-
+Example usage:
+with deduped as (
+    {{ dedupe(
+        source('raw_packet_db', 'addresses'),
+        key_fields=['id'],
+        sort_fields=['updated_at desc']
+    ) }}
+)
+....
+-#}
+    select {{field_list|join(', ')}}
+    from (
+        select {{field_list|join(', ')}},
+            row_number() over (partition by {{ key_fields|join(', ') }}{% if sort_fields %} order by {{ sort_fields|join(', ') }}{% endif %}) as rn
+        from {{ model }}
+        {%- if filter_list -%}
+            where {{ filter_list|join('\n and ') }}
+        {% endif %}
+    ) where rn = 1 -- dedupe
+{%- endmacro -%}

--- a/models/analytics/intermediate/d_conferences.sql
+++ b/models/analytics/intermediate/d_conferences.sql
@@ -1,6 +1,6 @@
 select
     /* Primary Key */
-    id
+    conference_id
 
     /* Properties */
     , conference_name

--- a/models/analytics/intermediate/d_conferences.yml
+++ b/models/analytics/intermediate/d_conferences.yml
@@ -5,7 +5,7 @@ models:
     description: Staged NHL conferences data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: conference_id
         description: Unique identifier for NHL conferences
         tests:
           - unique

--- a/models/analytics/intermediate/d_divisions.sql
+++ b/models/analytics/intermediate/d_divisions.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    id
+    division_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , conference_id
 
     /* Properties */

--- a/models/analytics/intermediate/d_divisions.yml
+++ b/models/analytics/intermediate/d_divisions.yml
@@ -5,15 +5,17 @@ models:
     description: Staged NHL division data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: division_id
         description: Unique identifier for NHL divisions
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: conference_id
         description: Foreign key that maps to the NHL conference
+        tests:
+          - not_null
 
       # Properties
       - name: division_name

--- a/models/analytics/intermediate/d_draft.sql
+++ b/models/analytics/intermediate/d_draft.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    id
+    stg_nhl__draft_id as draft_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , overall_pick_id
     , draft_prospect_id
     , draft_team_id

--- a/models/analytics/intermediate/d_draft.yml
+++ b/models/analytics/intermediate/d_draft.yml
@@ -5,21 +5,27 @@ models:
     description: Staged NHL entry draft data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: draft_id
         description: Unique identifier for an NHL rookie draft (generated via dbt_utils.surrogate_key)
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: overall_pick_id
         description: Unique identifier for an NHL rookie draft (draft year + overall pick)
+        tests:
+          - not_null
 
       - name: draft_prospect_id
         description: Foreign key that maps to an NHL draft prospect
+        tests:
+          - not_null
 
       - name: draft_team_id
         description: Foreign key that maps to the NHL team that drafted the NHL prospect
+        tests:
+          - not_null
 
       # Properties
       - name: draft_year

--- a/models/analytics/intermediate/d_draft_prospects.sql
+++ b/models/analytics/intermediate/d_draft_prospects.sql
@@ -1,8 +1,8 @@
 select distinct
     /* Primary Key */
-    id
+    draft_prospect_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , prospect_player_id
     , prospect_category_id
 

--- a/models/analytics/intermediate/d_draft_prospects.yml
+++ b/models/analytics/intermediate/d_draft_prospects.yml
@@ -5,18 +5,20 @@ models:
     description: Staged NHL draft_prospects data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: draft_prospect_id
         description: Unique identifier for a drafted NHL prospect
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: prospect_player_id
         description: Foreign key that maps to an NHL player ID
 
       - name: prospect_category_id
         description: Foreign key that maps to one of the four prospect categories - North American Skater (1), European Skater (2), North American Goalie (3) or European Goalie (4)
+        tests:
+          - not_null
 
       # Properties
       - name: prospect_first_name

--- a/models/analytics/intermediate/d_players.sql
+++ b/models/analytics/intermediate/d_players.sql
@@ -1,11 +1,14 @@
+with deduplicated as (
+    {{ dedupe(
+        ref('stg_nhl__players'),
+        key_fields=['player_id'],
+        sort_fields=['season_id']
+    ) }}
+)
+
 select
     /* Primary Key */
-    id
-
-    /* Foreign Keys */
-    , current_team_id
-    , team_id
-    , season_id
+    player_id
 
     /* Properties */
     , full_name
@@ -26,13 +29,11 @@ select
     , is_rookie
     , shoots_catches
     , roster_status
-    , current_team_name
-    , current_team_url
     , primary_position_code
     , primary_position_name
     , primary_position_type
     , primary_position_abbreviation
     , extracted_at
     , loaded_at
-from {{ ref('stg_nhl__players') }}
+from deduplicated
 

--- a/models/analytics/intermediate/d_players.yml
+++ b/models/analytics/intermediate/d_players.yml
@@ -11,21 +11,11 @@ models:
             - season_id
     columns:
       # Primary Key
-      - name: id
+      - name: player_id
         description: Unique identifier for an NHL player
         tests:
           - not_null
 
-      # Foreign Keys
-      - name: current_team_id
-        description: Foreign key that maps to the NHL team ID that the NHL player currently plays for
-
-      - name: team_id
-        description: Foreign key that maps to the NHL team ID that the NHL player played for in a given season
-
-      - name: season_id
-        description: Foreign key that maps to the NHL season that player was in
-        
       # Properties
       - name: full_name
         description: Full name of the NHL player
@@ -80,12 +70,6 @@ models:
 
       - name: roster_status
         description: Roster status of the NHL player (e.g. Y, N, I)
-
-      - name: current_team_name
-        description: Name of the NHL team the player currently plays for
-
-      - name: current_team_url
-        description: URL endpoint for current NHL team
 
       - name: primary_position_code
         description: Position code of the position most played (e.g. C, L, D)

--- a/models/analytics/intermediate/d_players.yml
+++ b/models/analytics/intermediate/d_players.yml
@@ -3,12 +3,6 @@ version: 2
 models:
   - name: d_players
     description: Staged NHL player data from the NHL-API
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - id
-            - team_id
-            - season_id
     columns:
       # Primary Key
       - name: player_id

--- a/models/analytics/intermediate/d_schedule.sql
+++ b/models/analytics/intermediate/d_schedule.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    id
+    stg_nhl__schedule_id as schedule_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , game_id
     , season_id
     , away_team_id

--- a/models/analytics/intermediate/d_schedule.yml
+++ b/models/analytics/intermediate/d_schedule.yml
@@ -5,29 +5,38 @@ models:
     description: Staged NHL schedule data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: schedule_id
         description: Unique identifier for NHL scheduled games
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to an NHL game
           {{ doc("game_id_description") }}
+        tests:
+          - not_null
+          - unique
 
       - name: season_id
         description: Foreign key that maps to an NHL season
+        tests:
+          - not_null
 
       - name: away_team_id
         description: Foreign key that maps to an NHL team (away team)
+        tests:
+          - not_null
 
       - name: home_team_id
         description: Foreign key that maps to an NHL team (home team)
+        tests:
+          - not_null
 
       - name: venue_id
-        description: Foreign key tha tmaps to a team's venu (home team)
+        description: Foreign key tha tmaps to a team's venue (home team)
 
       # Properties
       - name: game_number

--- a/models/analytics/intermediate/d_seasons.sql
+++ b/models/analytics/intermediate/d_seasons.sql
@@ -1,6 +1,6 @@
 select
     /* Primary Key */
-    id
+    season_id
 
     /* Properties */
     , regular_season_start_date

--- a/models/analytics/intermediate/d_seasons.yml
+++ b/models/analytics/intermediate/d_seasons.yml
@@ -5,7 +5,7 @@ models:
     description: Staged NHL seasons data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: season_id
         description: Unique identifier for an NHL season (e.g. "20172018")
         tests:
           - unique

--- a/models/analytics/intermediate/d_teams.sql
+++ b/models/analytics/intermediate/d_teams.sql
@@ -1,9 +1,17 @@
+with deduplicated as (
+    {{ dedupe(
+        ref('stg_nhl__teams'),
+        key_fields=['team_id'],
+        sort_fields=['season_id']
+    ) }}
+)
+
 select
     /* Primary Key */
-    id
+    team_id
 
-    /* Foreign Keys */
-
+    /* Identifiers */
+    , venue_timezone_id
     , division_id
     , conference_id
     , franchise_id
@@ -22,4 +30,4 @@ select
     , first_year_of_play
     , short_name
     , is_active
-from {{ ref('stg_nhl__teams') }}
+from deduplicated

--- a/models/analytics/intermediate/d_teams.yml
+++ b/models/analytics/intermediate/d_teams.yml
@@ -5,25 +5,34 @@ models:
     description: Staged NHL teams data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: team_id
         description: Unique identifier for NHL teams
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: venue_timezone_id
         description: Foreign key that maps to the timezone ID of the venue (e.g. America/Vancouver)
+        tests:
+          - not_null
 
       - name: division_id
         description: Foreign key that maps to the division ID that the NHL team belongs to
+        tests:
+          - not_null
 
       - name: conference_id
         description: Foreign key that maps to the conference ID that the NHL team belongs to
+        tests:
+          - not_null
 
       - name: franchise_id
         description: Foreign key that maps to the franchise ID that the NHL originates from
+        tests:
+          - not_null
 
+      # Properties
       - name: full_name
         description: Full name of the NHL team (e.g. Vancouver Canucks)
 

--- a/models/analytics/intermediate/f_boxscore.sql
+++ b/models/analytics/intermediate/f_boxscore.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    id
+    stg_nhl__boxscore_id as boxscore_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , game_id
     , home_team_id
     , away_team_id

--- a/models/analytics/intermediate/f_boxscore.yml
+++ b/models/analytics/intermediate/f_boxscore.yml
@@ -7,23 +7,29 @@ models:
       Contains summarized stats of the teams involved at the game level.
     columns:
       # Primary Key
-      - name: id
+      - name: boxscore_id
         description: Unique identifier for the NHL boxscore game (hashed representation of game_id)
         tests:
           - not_null
           - unique
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to an NHL game
           {{ doc("game_id_description") }}
+        tests:
+          - not_null
 
       - name: home_team_id
         description: Identifier for the home team, foreign key to stg_nhl__teams
+        tests:
+          - not_null
 
       - name: away_team_id
         description: Identifier for the away team, foreign key to stg_nhl__teams
+        tests:
+          - not_null
 
       # Properties
       - name: home_team_name

--- a/models/analytics/intermediate/f_boxscore_player.sql
+++ b/models/analytics/intermediate/f_boxscore_player.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    id
+    stg_nhl__boxscore_player_id as boxscore_player_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , game_id
     , team_id
     , player_id

--- a/models/analytics/intermediate/f_boxscore_player.yml
+++ b/models/analytics/intermediate/f_boxscore_player.yml
@@ -5,20 +5,24 @@ models:
     description: Staged NHL boxscore player data from the NHL-API (game-player level). Each row represents an individual player's summarized activity in an NHL game
     columns:
       # Primary Key
-      - name: id
+      - name: boxscore_player_id
         description: Unique identifier for a player's summarized activity in an NHL game (game_id + team_id + player_id)
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to an NHL game ID
           {{ doc("game_id_description") }}
+        tests:
+          - not_null
 
       - name: team_id
         description: Foreign key that maps to an NHL team ID
+        tests:
+          - not_null
 
       - name: player_id
         description: Foreign key that maps to an NHL player ID

--- a/models/analytics/intermediate/f_boxscore_team.sql
+++ b/models/analytics/intermediate/f_boxscore_team.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    id
+    stg_nhl__boxscore_team_id as boxscore_team_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , game_id
     , team_id
 

--- a/models/analytics/intermediate/f_boxscore_team.yml
+++ b/models/analytics/intermediate/f_boxscore_team.yml
@@ -5,20 +5,24 @@ models:
     description: Staged NHL boxscore game data from the NHL-API (game-team level)
     columns:
       # Primary Key
-      - name: id
+      - name: boxscore_team_id
         description: Unique identifier for an team's involvement in an NHL game (hashed representation of game_id + team_id)
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to the NHL game ID - each game should have 2 rows in this table for each team involved in the game
           {{ doc("game_id_description") }}
+        tests:
+          - not_null
 
       - name: team_id
         description: Foreign key that maps to the NHL team ID - each row represents a team playing in a game
+        tests:
+          - not_null
 
       # Properties
       - name: team_type

--- a/models/analytics/intermediate/f_games.sql
+++ b/models/analytics/intermediate/f_games.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    id
+    game_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , home_team_id
     , away_team_id
 

--- a/models/analytics/intermediate/f_games.yml
+++ b/models/analytics/intermediate/f_games.yml
@@ -5,7 +5,7 @@ models:
     description: Staged NHL boxscore & linescore data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: game_id
         description: |
           Unique identifier for an NHL game (game_id)
           {{ doc("game_id_description") }}
@@ -13,17 +13,16 @@ models:
           - unique
           - not_null
 
-      # Foreign Keys
-      - name: game_id
-        description: |
-          Unique identifier for an NHL game (game_id)
-          {{ doc("game_id_description") }}
-
+      # Identifiers
       - name: home_team_id
         description: Foreign key that maps to an NHL team (home team)
+        tests:
+          - not_null
 
       - name: away_team_id
         description: Foreign key that maps to an NHL team (away team)
+        tests:
+          - not_null
 
       # Properties
       - name: game_score_description

--- a/models/analytics/intermediate/f_linescore.sql
+++ b/models/analytics/intermediate/f_linescore.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    id
+    stg_nhl__linescore_id as linescore_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , game_id
     , home_team_id
     , away_team_id

--- a/models/analytics/intermediate/f_linescore.yml
+++ b/models/analytics/intermediate/f_linescore.yml
@@ -7,7 +7,7 @@ models:
       Contains the summary of goals and teams involved at the game level.
     columns:
       # Primary Key
-      - name: id
+      - name: linescore_id
         description: |
           Unique identifier for an NHL game (hashed representation of game_id)
           {{ doc("game_id_description") }}
@@ -15,7 +15,7 @@ models:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Unique identifier for an NHL game (game_id)
@@ -23,12 +23,18 @@ models:
 
       - name: home_team_id
         description: Identifier for the home team, foreign key to stg_nhl__teams
+        tests:
+          - not_null
 
       - name: away_team_id
         description: Identifier for the away team, foreign key to stg_nhl__teams
+        tests:
+          - not_null
 
       - name: game_winning_team_id
         description: Identifier for the winning team, foreign key to stg_nhl__teams
+        tests:
+          - not_null
 
       # Properties
       - name: game_score_description

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    id
+    stg_nhl__live_plays_id as play_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , game_id
     , event_idx
     , event_id

--- a/models/analytics/intermediate/f_plays.yml
+++ b/models/analytics/intermediate/f_plays.yml
@@ -5,29 +5,39 @@ models:
     description: Staged NHL event level data from the NHL-API (player-play level)
     columns:
       # Primary Key
-      - name: id
+      - name: play_id
         description: Unique identifier for a player's event-level activity in an NHL game (hashed representation of game_id + team_id + player_id + event_id)
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to an NHL game ID
           {{ doc("game_id_description") }}
+        tests:
+          - not_null
 
       - name: event_idx
         description: Foreign key that maps to the sequence of the event relative to that game, in ascending order (e.g. 1 = first event, 2 - second event)
+        tests:
+          - not_null
 
       - name: event_id
         description: Foreign key that maps to a distinct event ID
+        tests:
+          - not_null
 
       - name: player_id
         description: Foreign key that maps to an NHL player ID
+        tests:
+          - not_null
 
       - name: team_id
         description: Foreign key that maps to an NHL team ID
+        tests:
+          - not_null
 
       # Properties
       - name: player_role

--- a/models/staging/stg_nhl__boxscore.sql
+++ b/models/staging/stg_nhl__boxscore.sql
@@ -6,9 +6,9 @@ live_boxscore as (
 , final as (
     select
         /* Primary Key */
-        {{ dbt_utils.surrogate_key(['gameid']) }} as id
+        {{ dbt_utils.surrogate_key(['gameid']) }} as stg_nhl__boxscore_id
 
-        /* Foreign Keys */
+        /* Identifiers */
         , gameid as game_id
         , teams.home.team.id as home_team_id
         , teams.away.team.id as away_team_id

--- a/models/staging/stg_nhl__boxscore.yml
+++ b/models/staging/stg_nhl__boxscore.yml
@@ -7,13 +7,13 @@ models:
       Contains summarized stats of the teams involved at the game level.
     columns:
       # Primary Key
-      - name: id
-        description: Unique identifier for the NHL boxscore game
+      - name: stg_nhl__boxscore_id
+        description: Unique surrogate key for the NHL boxscore game
         tests:
           - not_null
           - unique
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to an NHL game

--- a/models/staging/stg_nhl__boxscore_player.sql
+++ b/models/staging/stg_nhl__boxscore_player.sql
@@ -10,11 +10,8 @@ live_boxscore as (
 -- CTE2
 , home_team_player as (
     select
-        /* Primary Key */
-        {{ dbt_utils.surrogate_key(['live_boxscore.gameid', 'teams.home.team.id', 'home_players.person.id']) }} as id
-
-        /* Foreign Keys */
-        , live_boxscore.gameid as game_id
+        /* Identifiers */
+        live_boxscore.gameid as game_id
         , teams.home.team.id as team_id
         , home_players.person.id as player_id
 
@@ -66,14 +63,10 @@ live_boxscore as (
 -- CTE3
 , away_team_player as (
     select
-        /* Primary Key */
-        concat(live_boxscore.gameid, teams.away.team.id, away_players.person.id) as id
-
-        /* Foreign Keys */
-        , live_boxscore.gameid as game_id
+        /* Identifiers */
+        live_boxscore.gameid as game_id
         , teams.away.team.id as team_id
         , away_players.person.id as player_id
-
 
         /* Properties */
         , teams.away.team.name as team_name
@@ -131,9 +124,9 @@ live_boxscore as (
 -- Final query, return everything
 select
     /* Primary Key */
-    {{ dbt_utils.surrogate_key(['boxscore_player.id']) }} as id
+    {{ dbt_utils.surrogate_key(['boxscore_player.game_id', 'boxscore_player.team_id', 'boxscore_player.player_id']) }} as stg_nhl__boxscore_player_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , boxscore_player.game_id
     , boxscore_player.team_id
     , boxscore_player.player_id

--- a/models/staging/stg_nhl__boxscore_player.yml
+++ b/models/staging/stg_nhl__boxscore_player.yml
@@ -5,13 +5,13 @@ models:
     description: Staged NHL boxscore player data from the NHL-API (game-player level). Each row represents an individual player's summarized activity in an NHL game
     columns:
       # Primary Key
-      - name: id
-        description: Unique identifier for a player's summarized activity in an NHL game (game_id + team_id + player_id)
+      - name: stg_nhl__boxscore_player_id
+        description: Unique surrogate key for a player's summarized activity in an NHL game (game_id + team_id + player_id)
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to an NHL game ID

--- a/models/staging/stg_nhl__boxscore_team.sql
+++ b/models/staging/stg_nhl__boxscore_team.sql
@@ -8,11 +8,8 @@ live_boxscore as (
 -- CTE2
 , home_team as (
     select
-        /* Primary Key */
-        {{ dbt_utils.surrogate_key(['live_boxscore.gameid', 'teams.home.team.id']) }} as id
-
-        /* Foreign Keys */
-        , live_boxscore.gameid as game_id
+        /* Identifiers */
+        live_boxscore.gameid as game_id
         , teams.home.team.id as team_id
 
         /* Properties */
@@ -37,11 +34,8 @@ live_boxscore as (
 -- CTE2
 , away_team as (
     select
-        /* Primary Key */
-        concat(live_boxscore.gameid, teams.away.team.id ) as id
-
-        /* Foreign Keys */
-        , live_boxscore.gameid as game_id
+        /* Identifiers */
+        live_boxscore.gameid as game_id
         , teams.away.team.id as team_id
 
         /* Properties */
@@ -67,8 +61,8 @@ live_boxscore as (
 , winning_team as (
     select
         home_team.game_id
-        , home_team.id as home_team_id
-        , away_team.id as away_team_id
+        , home_team.team_id as home_team_id
+        , away_team.team_id as away_team_id
         , home_team.team_goals as home_team_score
         , away_team.team_goals as away_team_score
         , case
@@ -92,9 +86,9 @@ live_boxscore as (
 -- Final query, return everything
 select
     /* Primary Key */
-    {{ dbt_utils.surrogate_key(['boxscore_team.id']) }} as id
+    {{ dbt_utils.surrogate_key(['boxscore_team.game_id', 'boxscore_team.team_id']) }} as stg_nhl__boxscore_team_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , boxscore_team.game_id
     , boxscore_team.team_id
 

--- a/models/staging/stg_nhl__boxscore_team.yml
+++ b/models/staging/stg_nhl__boxscore_team.yml
@@ -5,13 +5,13 @@ models:
     description: Staged NHL boxscore game data from the NHL-API (game-team level)
     columns:
       # Primary Key
-      - name: id
-        description: Unique identifier for an team's involvement in an NHL game (game_id + team_id)
+      - name: stg_nhl__boxscore_team_id
+        description: Unique surrogate key for a team's involvement in an NHL game (game_id + team_id)
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to the NHL game ID - each game should have 2 rows in this table for each team involved in the game

--- a/models/staging/stg_nhl__conferences.sql
+++ b/models/staging/stg_nhl__conferences.sql
@@ -1,6 +1,9 @@
 select
     /* Primary Key */
-    conferences.id as id
+    {{ dbt_utils.surrogate_key(['conferences.id']) }} as stg_nhl__conferences_id
+
+    /* Identifiers */
+    , conferences.id as conference_id
 
     /* Properties */
     , conferences.name as conference_name

--- a/models/staging/stg_nhl__conferences.yml
+++ b/models/staging/stg_nhl__conferences.yml
@@ -5,7 +5,14 @@ models:
     description: Staged NHL conferences data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: stg_nhl__conferences_id
+        description: Unique surrogate key for NHL conferences
+        tests:
+          - unique
+          - not_null
+
+      # Identifiers
+      - name: conference_id
         description: Unique identifier for NHL conferences
         tests:
           - unique

--- a/models/staging/stg_nhl__divisions.sql
+++ b/models/staging/stg_nhl__divisions.sql
@@ -1,8 +1,9 @@
 select
     /* Primary Key */
-    divisions.id as id
+    {{ dbt_utils.surrogate_key(['divisions.id']) }} as stg_nhl__divisions_id
 
-    /* Foreign Keys */
+    /* Identifiers */
+    , divisions.id as division_id
     , divisions.conference.id as conference_id
 
     /* Properties */

--- a/models/staging/stg_nhl__divisions.yml
+++ b/models/staging/stg_nhl__divisions.yml
@@ -5,13 +5,19 @@ models:
     description: Staged NHL division data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: stg_nhl__divisions_id
+        description: Unique surrogate key for NHL divisions
+        tests:
+          - unique
+          - not_null
+
+      # Identifiers
+      - name: division_id
         description: Unique identifier for NHL divisions
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
       - name: conference_id
         description: Foreign key that maps to the NHL conference
 

--- a/models/staging/stg_nhl__draft.sql
+++ b/models/staging/stg_nhl__draft.sql
@@ -1,9 +1,9 @@
 select
     /* Primary Key */
-    {{ dbt_utils.surrogate_key(['year', 'pickoverall']) }} as id
+    {{ dbt_utils.surrogate_key(['year', 'pickoverall']) }} as stg_nhl__draft_id
 
-    /* Foreign Keys */
-    , CONCAT(CAST(draft.year as STRING), LPAD(CAST(draft.pickoverall as STRING), 3, '0')) as overall_pick_id
+    /* Identifiers */
+    , concat(cast(draft.year as string), lpad(cast(draft.pickoverall as string), 3, '0')) as overall_pick_id
     , draft.prospect.id as draft_prospect_id
     , draft.team.id as draft_team_id
 
@@ -17,3 +17,4 @@ select
     , draft.team.name as draft_team_name
 
 from {{ source('meltano', 'draft') }} as draft
+where draft.prospect.fullname != 'Void' -- remove records that contain draft prospect named 'Void' as this appears to be bad data from the API

--- a/models/staging/stg_nhl__draft.yml
+++ b/models/staging/stg_nhl__draft.yml
@@ -5,13 +5,13 @@ models:
     description: Staged NHL entry draft data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: stg_nhl__draft_id
         description: Unique identifier for an NHL rookie draft (generated via dbt_utils.surrogate_key)
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: overall_pick_id
         description: Unique identifier for an NHL rookie draft (draft year + overall pick)
 

--- a/models/staging/stg_nhl__draft_prospects.sql
+++ b/models/staging/stg_nhl__draft_prospects.sql
@@ -1,8 +1,9 @@
 select distinct
     /* Primary Key */
-    {{ dbt_utils.surrogate_key(['prospects.id']) }} as id
+    {{ dbt_utils.surrogate_key(['prospects.id', 'prospects.nhlplayerid']) }} as stg_nhl__draft_prospects_id
 
-    /* Foreign Keys */
+    /* Identifiers */
+    , prospects.id as draft_prospect_id
     , prospects.nhlplayerid as prospect_player_id
     , prospects.prospectcategory.id as prospect_category_id
 

--- a/models/staging/stg_nhl__draft_prospects.yml
+++ b/models/staging/stg_nhl__draft_prospects.yml
@@ -5,13 +5,19 @@ models:
     description: Staged NHL draft_prospects data from the NHL-API
     columns:
       # Primary Key
-      - name: id
-        description: Unique identifier for a drafted NHL prospect
+      - name: stg_nhl__draft_prospects_id
+        description: Unique surrogate key for a drafted NHL prospect
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
+      - name: draft_prospect_id
+        description: Unique identifier for the NHL draft prospect
+        tests:
+          - not_null
+          - unique
+
       - name: prospect_player_id
         description: Foreign key that maps to an NHL player ID
 

--- a/models/staging/stg_nhl__games.sql
+++ b/models/staging/stg_nhl__games.sql
@@ -10,9 +10,10 @@ linescore as (
 , final as (
     select
         /* Primary Key */
-        linescore.game_id as id
+        {{ dbt_utils.surrogate_key(['linescore.game_id']) }} as stg_nhl__games_id
 
-        /* Foreign Keys */
+        /* Identifiers */
+        , linescore.game_id
         , linescore.home_team_id
         , linescore.away_team_id
 

--- a/models/staging/stg_nhl__games.yml
+++ b/models/staging/stg_nhl__games.yml
@@ -5,19 +5,20 @@ models:
     description: Staged NHL boxscore & linescore data from the NHL-API
     columns:
       # Primary Key
-      - name: id
-        description: |
-          Unique identifier for an NHL game (game_id)
-          {{ doc("game_id_description") }}
+      - name: stg_nhl__games_id
+        description: Unique surrogate key for an NHL game
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Unique identifier for an NHL game (game_id)
           {{ doc("game_id_description") }}
+        tests:
+          - not_null
+          - unique
 
       - name: home_team_id
         description: Foreign key that maps to an NHL team (home team)

--- a/models/staging/stg_nhl__linescore.sql
+++ b/models/staging/stg_nhl__linescore.sql
@@ -6,9 +6,9 @@ live_linescore as (
 , final as (
     select
         /* Primary Key */
-        {{ dbt_utils.surrogate_key(['gameid']) }} as id
+        {{ dbt_utils.surrogate_key(['gameid']) }} as stg_nhl__linescore_id
 
-        /* Foreign Keys */
+        /* Identifiers */
         , gameid as game_id
         , teams.home.team.id as home_team_id
         , teams.away.team.id as away_team_id

--- a/models/staging/stg_nhl__linescore.yml
+++ b/models/staging/stg_nhl__linescore.yml
@@ -7,15 +7,13 @@ models:
       Contains the summary of goals and teams involved at the game level.
     columns:
       # Primary Key
-      - name: id
-        description: |
-          Unique identifier for an NHL game (game_id)
-          {{ doc("game_id_description") }}
+      - name: stg_nhl__linescore_id
+        description: Unique identifier for the game linescore
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Unique identifier for an NHL game (game_id)

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -8,7 +8,7 @@ live_plays as (
 -- CTE2 Play-level information (each row is a player's involvement in a play)
 , cte_base_plays as (
     select
-        concat(live_plays.gameid, live_plays.about.eventidx, players.player.id) as id
+        {{ dbt_utils.surrogate_key(['live_plays.gameid', 'live_plays.about.eventidx', 'players.player.id']) }} as stg_nhl__live_plays_id
         , live_plays.gameid as game_id
         , live_plays.about.eventid as event_id
         , players.player.id as player_id
@@ -177,9 +177,9 @@ live_plays as (
 , cte_cumulative as (
     select
         /* Primary Key */
-        bp.id
+        bp.stg_nhl__live_plays_id
 
-        /* Foreign Keys */
+        /* Identifiers */
         , bp.game_id
         , bp.event_idx
         , bp.event_id
@@ -401,9 +401,9 @@ live_plays as (
 -- Final return
 select
     /* Primary Key */
-    {{ dbt_utils.surrogate_key(['id']) }} as id
+    stg_nhl__live_plays_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , game_id
     , event_idx
     , event_id

--- a/models/staging/stg_nhl__live_plays.yml
+++ b/models/staging/stg_nhl__live_plays.yml
@@ -5,13 +5,13 @@ models:
     description: Staged NHL event level data from the NHL-API (player-play level)
     columns:
       # Primary Key
-      - name: id
-        description: Unique identifier for a player's event-level activity in an NHL game (game_id + team_id + player_id + event_id)
+      - name: stg_nhl__live_plays_id
+        description: Unique surrogate key for a player's event-level activity in an NHL game (game_id + team_id + player_id + event_id)
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to an NHL game ID

--- a/models/staging/stg_nhl__players.sql
+++ b/models/staging/stg_nhl__players.sql
@@ -1,9 +1,9 @@
 select
     /* Primary Key */
-    players.id as id
+    {{ dbt_utils.surrogate_key(['players.id', 'players.teamid', 'players.seasonid'])}} as stg_nhl__players_id
 
-    /* Foreign Keys */
-    , currentteam.id as current_team_id
+    /* Identifiers */
+    , players.id as player_id
     , players.seasonid as season_id
     , players.teamid as team_id
 
@@ -26,8 +26,6 @@ select
     , players.rookie as is_rookie
     , players.shootscatches as shoots_catches
     , players.rosterstatus as roster_status
-    , players.currentteam.name as current_team_name
-    , players.currentteam.link as current_team_url
     , players.primaryposition.code as primary_position_code
     , players.primaryposition.name as primary_position_name
     , players.primaryposition.type as primary_position_type

--- a/models/staging/stg_nhl__players.sql
+++ b/models/staging/stg_nhl__players.sql
@@ -1,6 +1,6 @@
 select
     /* Primary Key */
-    {{ dbt_utils.surrogate_key(['players.id', 'players.teamid', 'players.seasonid'])}} as stg_nhl__players_id
+    {{ dbt_utils.surrogate_key(['players.id', 'players.teamid', 'players.seasonid']) }} as stg_nhl__players_id
 
     /* Identifiers */
     , players.id as player_id

--- a/models/staging/stg_nhl__players.yml
+++ b/models/staging/stg_nhl__players.yml
@@ -11,14 +11,22 @@ models:
             - team_id
     columns:
       # Primary Key
-      - name: id
+      - name: stg_nhl__players_id
+        description: Unique surrogate key from a combination of the NHL player ID, team ID and the season ID
+        tests:
+          - not_null
+
+      # Identifiers
+      - name: player_id
         description: Unique identifier for an NHL player
         tests:
           - not_null
 
-      # Foreign Keys
-      - name: current_team_id
-        description: Foreign key that maps to the NHL team ID that the NHL player currently plays for
+      - name: team_id
+        description: Foreign key that maps to the NHL team ID that the NHL player played for in a given season
+
+      - name: season_id
+        description: Foreign key that maps to the NHL season that player was in
 
       - name: team_id
         description: Foreign key that maps to the NHL team ID that the NHL player played for in a given season
@@ -83,12 +91,6 @@ models:
 
       - name: roster_status
         description: Roster status of the NHL player (e.g. Y, N, I)
-
-      - name: current_team_name
-        description: Name of the NHL team the player currently plays for
-
-      - name: current_team_url
-        description: URL endpoint for current NHL team
 
       - name: primary_position_code
         description: Position code of the position most played (e.g. C, L, D)

--- a/models/staging/stg_nhl__players.yml
+++ b/models/staging/stg_nhl__players.yml
@@ -3,12 +3,6 @@ version: 2
 models:
   - name: stg_nhl__players
     description: Staged NHL player data from the NHL-API
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          combination_of_columns:
-            - id
-            - season_id
-            - team_id
     columns:
       # Primary Key
       - name: stg_nhl__players_id

--- a/models/staging/stg_nhl__schedule.sql
+++ b/models/staging/stg_nhl__schedule.sql
@@ -1,8 +1,8 @@
 select
     /* Primary Key */
-    {{ dbt_utils.surrogate_key(['gamepk']) }} as id
+    {{ dbt_utils.surrogate_key(['schedule.gamepk', 'schedule.season']) }} as stg_nhl__schedule_id
 
-    /* Foreign Keys */
+    /* Identifiers */
     , schedule.gamepk as game_id
     , schedule.season as season_id
     , schedule.teams.away.team.id as away_team_id

--- a/models/staging/stg_nhl__schedule.yml
+++ b/models/staging/stg_nhl__schedule.yml
@@ -5,29 +5,38 @@ models:
     description: Staged NHL schedule data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: stg_nhl__schedule_id
         description: Unique identifier for NHL scheduled games
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
       - name: game_id
         description: |
           Foreign key that maps to an NHL game
           {{ doc("game_id_description") }}
+        tests:
+          - not_null
+          - unique
 
       - name: season_id
         description: Foreign key that maps to an NHL season
+        tests:
+          - not_null
 
       - name: away_team_id
         description: Foreign key that maps to an NHL team (away team)
+        tests:
+          - not_null
 
       - name: home_team_id
         description: Foreign key that maps to an NHL team (home team)
+        tests:
+          - not_null
 
       - name: venue_id
-        description: Foreign key tha tmaps to a team's venu (home team)
+        description: Foreign key tha tmaps to a team's venue (home team)
 
       # Properties
       - name: game_number

--- a/models/staging/stg_nhl__seasons.sql
+++ b/models/staging/stg_nhl__seasons.sql
@@ -1,6 +1,9 @@
 select
     /* Primary Key */
-    seasons.seasonid as id
+    {{ dbt_utils.surrogate_key(['seasons.seasonid']) }} as stg_nhl__seasons_id
+
+    /* Identifiers */
+    , seasons.seasonid as season_id
 
     /* Properties */
     , seasons.regularseasonstartdate as regular_season_start_date

--- a/models/staging/stg_nhl__seasons.yml
+++ b/models/staging/stg_nhl__seasons.yml
@@ -5,7 +5,14 @@ models:
     description: Staged NHL seasons data from the NHL-API
     columns:
       # Primary Key
-      - name: id
+      - name: stg_nhl__seasons_id
+        description: Unique surrogate key for an NHL season (e.g. "20172018")
+        tests:
+          - unique
+          - not_null
+
+      # Identifiers
+      - name: season_id
         description: Unique identifier for an NHL season (e.g. "20172018")
         tests:
           - unique

--- a/models/staging/stg_nhl__teams.sql
+++ b/models/staging/stg_nhl__teams.sql
@@ -1,12 +1,14 @@
 select
     /* Primary Key */
-    teams.id as id
+    {{ dbt_utils.surrogate_key(['teams.id', 'teams.seasonid']) }} as stg_nhl__teams_id
 
-    /* Foreign Keys */
+    /* Identifiers */
+    , teams.id as team_id
     , teams.venue.timezone.id as venue_timezone_id
     , teams.division.id as division_id
     , teams.conference.id as conference_id
     , teams.franchise.franchiseid as franchise_id
+    , teams.seasonid as season_id
 
     /* Properties */
     , teams.name as full_name

--- a/models/staging/stg_nhl__teams.yml
+++ b/models/staging/stg_nhl__teams.yml
@@ -5,13 +5,18 @@ models:
     description: Staged NHL teams data from the NHL-API
     columns:
       # Primary Key
-      - name: id
-        description: Unique identifier for NHL teams
+      - name: stg_nhl__teams_id
+        description: Primary key, combination of the NHL team ID and the season ID
         tests:
           - unique
           - not_null
 
-      # Foreign Keys
+      # Identifiers
+      - name: team_id
+        description: Unique identifier for NHL teams
+        tests:
+          - not_null
+
       - name: venue_timezone_id
         description: Foreign key that maps to the timezone ID of the venue (e.g. America/Vancouver)
 
@@ -24,6 +29,10 @@ models:
       - name: franchise_id
         description: Foreign key that maps to the franchise ID that the NHL originates from
 
+      - name: season_id
+        description: Foreign key that maps to the season ID that the NHL team roster relates to
+
+      # Properties
       - name: full_name
         description: Full name of the NHL team (e.g. Vancouver Canucks)
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ rules = L001,L003,L004,L005,L006,L007,L008,L010,L011,L012,L014,L015,L017,L018,L0
 # L027 References should be qualified if select has more than one referenced table/view. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L027
 # L028 References should be consistent in statements with a single table. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L028
 # L030 Inconsistent capitalisation of function names, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L030
-# L035 Do not specify “else null” in a case when statement (redundant), sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L035
+# L035 Do not specify "else null" in a case when statement (redundant), sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L035
 # L036 Select targets should be on a new line unless there is only one select target, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L036
 # L037 Ambiguous ordering directions for columns in order by clause, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L037
 # L039 Unnecessary whitespace found, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L039


### PR DESCRIPTION
# Overview
Adding more years of data has resulting in the `raw` tables containing potential duplicate of players and teams having participated in multiple seasons. This PR introduces some duplication logic to maintain uniqueness at the `dim_` table level.

Resolves #23 

# Other notes
- New macro `dedupe()` for conveniently deduplicating source data

# Checks
- [x] All models ran successfully
- [x] Changes to models are reflected in the schema.yml
Pick one:
- [x] No test failures OR
- [ ] No new test failures, and there is a plan in place to address existing ones
