### PR TITLE
Primary and secondary assists in f_player_season

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-sqlfluff-templater-dbt = "*"
 dbt-bigquery = "*"
+sqlfluff-templater-dbt = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -191,7 +191,7 @@
                 "sha256:3763b4fc2ef91063ba72b50214652224b2d0a9f31544d5504596f5c4a847cd7b",
                 "sha256:fb54e906bf48fd7d4b85950b9dc5b483642213a1b2fb9ba0abcb9103d7c747c4"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.2'",
+            "markers": "python_full_version >= '3.6.2' and python_full_version < '4.0.0'",
             "version": "==6.5.0"
         },
         "future": {
@@ -292,78 +292,78 @@
         },
         "googleapis-common-protos": {
             "hashes": [
-                "sha256:4007500795bcfc269d279f0f7d253ae18d6dc1ff5d5a73613ffe452038b1ec5f",
-                "sha256:60220c89b8bd5272159bed4929ecdc1243ae1f73437883a499a44a1cbc084086"
+                "sha256:6b5ee59dc646eb61a8eb65ee1db186d3df6687c8804830024f32573298bca19b",
+                "sha256:ddcd955b5bb6589368f659fa475373faa1ed7d09cde5ba25e88513d87007e174"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.56.0"
+            "version": "==1.56.1"
         },
         "grpcio": {
             "hashes": [
-                "sha256:1419ab58c830f2da40884f4e1b4583038b12d6609fcac1a5700eff9ca9a75070",
-                "sha256:170ade19379157d5c8e01c8176858a7ffbbf904b7896917c323134021afc1926",
-                "sha256:19646d7d51643231fbd3414134ddbf5c4c226db861a800bc8c04ac870533b614",
-                "sha256:1efd92661c4d4b106cd97025d52a480255b387ba75d3070cee6c4677e375f1c5",
-                "sha256:206becfce3ad377f50c934b4d91f3fd5f101fe71db80ccce800d6bb898605448",
-                "sha256:20fde26fbd40547c65817ca47b15f1f51d4bb0a70fd8a836fa08c9ad9b284b03",
-                "sha256:25cf4ede6f9703913b4381969159452ff6ca5dfb93d5f58b80d1763e9ad79b18",
-                "sha256:26ab8415e2e048e32cf05a86e7b6d76864bc018f837a93112c177130c2743766",
-                "sha256:2a751c533679dbc0194daf91a6e665d6163f9b423fc6f2e506035ddc17118f9d",
-                "sha256:2f59d6beb12bbccd3d1ecd23d78f0f1a63324cddc42c744c6d13abeef6039496",
-                "sha256:47f0c0820d0b7f6e4930729b9067f346a07d4bbc632d109a2bcc7ca6f260c5f1",
-                "sha256:4be2d7f283a7e2a15f9c5d70e1c9899e1824ea0650dbd82b7dc5e54d0c8061a5",
-                "sha256:4befe75c0122fe51ae046a4936b735c306ea63849405cd8dc0be534affd60ea0",
-                "sha256:518b3294dcdd734c4551a7c4cf3b457b9e0b949f4d855419600ceb7921de6f00",
-                "sha256:63e827caff24f7d02c2d4d6fbca720001f7e5158a68abba37ea0c7eb447adfe5",
-                "sha256:653d69bc4ac2e1f1bf36625aa42fbba8d399df609ded69a74b5820ca995e75dd",
-                "sha256:65477bb9e884c9f46cde27c083d69c6588342f24ee5d56bbf731b9a4a14cc781",
-                "sha256:666d40de9e323392f985921c4d112ebda8decd7a4532b9524f7e6f6fd5e4ca57",
-                "sha256:668cc3e277f2bb88189bb4f0d7dfece326be789096660f94553600040630969c",
-                "sha256:6ab4aeadc6c76447bcae91da1c69eeff9d0b78af7051fdcebe18a4cdf766f727",
-                "sha256:70b6d401a758e85318a2be038eccf8ab965a14082b9f89152f19b8f9b7ac762e",
-                "sha256:7c4fff11237fee6f07ac6937f2cff02a1f28d8bf2d675d1c57496423ddb8e01f",
-                "sha256:7c6958a8a6a8df1caa536314bda3fb54f9ca5c936c14e3a486ff51d150c342c7",
-                "sha256:7e4972b82ee1164eeee297e86a6351a2f358e1a9e5b65ae491a7a140d276cec4",
-                "sha256:80aa6247a77cba60b56192df57cc5d78f0e2fe697fc6ebdf089ce93df894db3e",
-                "sha256:828078cb73008c65794af94201c975610d16c9440b00e5efefc9e45dd23de73b",
-                "sha256:884b0182d89bb934a5615f9d056df44e8681473cd124e6262382b5888353691b",
-                "sha256:9ab12c5bfb13f294f6215a2580e446396eaac1b101e6cdb74d7bea3c6be3143e",
-                "sha256:9e70290273b9d7e6d1cd8f8a7a621c4e9a91a3a35be3068610ee014124a35e75",
-                "sha256:9e7ea7a8e7521664dd630fab35daab106a490b65e29254f90aeac66ec5cf1f68",
-                "sha256:a4d4a17d8afcd6c9e4f06cf52b3f7ce0ca06f33510a47358848d30a1aebef10b",
-                "sha256:a6d45e6fbe3f60fa3a8907f55e8d626a4aa452eb108edfa7f533c9161d973ef9",
-                "sha256:afe8cbd4ed74f7d955c7732195d5f46c6af7b0867dfe642c8628332585fa40ee",
-                "sha256:b3004fd04bfd3dba17f9d28b094bff76a32d7e85408f9f26f02594aa31fba040",
-                "sha256:b45f4f0815e1df26ced52e6e7012055d023d1b2d943e5d3d168e211bdbb823ad",
-                "sha256:bd58caa70b4228ebb31e1b5c9872053f9fde4412ef69a1be65b8a8eaae8cf072",
-                "sha256:bdad8c088e088e5d34e9c10a5db8871157cc1a7e42f49ea4bd320fd8b57e7eb2",
-                "sha256:c1111369863d04ea49378b73c1c2890bafa4c558c9cf799da52bf922483c8a3c",
-                "sha256:c2fe454b7dd4c41a9cb8fbbb18474fd9a2f7935ac203b5f47a00216beec8aacd",
-                "sha256:c8539a82debdd50c7fe3f0565b36b5efcd6a68f30ab635aced4175569d5f45e2",
-                "sha256:c8c0eaede86ae97213548633eb07446dab75a48c771ad8bb3751bffbd9055ea9",
-                "sha256:c95497d9bf93c8553b558646dd61cb4b15269c28fcee1a8843892edd50f3754f",
-                "sha256:cbfc0c85a2eb34de711028fe9630b159a1c0df5580359368bff8429596c56c97",
-                "sha256:d2b99b28b75b1929d92d947b74b7c74610131ac6acf803f2dedde7d245bc8b90",
-                "sha256:d518477a73b467953ac8cff08022394b5250e8cfd7adfd167f76fd2d76969158",
-                "sha256:d5ef9194f9bc216c8d0c18885bb7db247b0018a219ded543a6a6c2fe9454b220",
-                "sha256:e30a1be3d1ec426f32d6fa22d9af9f5169a40d4b0955ce1fb111e869e0c0f44f",
-                "sha256:eca51dd5d16b3a6b19c255cbcb236387d5cc9e058faeff024cd0c904d16f2495",
-                "sha256:ed29cc8cb0394cb5ae9cf0a56e32228e9d98b8bb79a088393a18346510a06132",
-                "sha256:edc0e052d349d7bac6719bddb5e779314b060eca1f53f99e0cc0be1aea66285a",
-                "sha256:ef37ff444d248ff8ea5e175a7807ce19e324831bc00d466169191cd9aad0ee36",
-                "sha256:fa4834022ca45fcde57fabcd12e5458fdb01372c4c8ab84030eabec24c6f39ca",
-                "sha256:fbfac305c16cb5fcff894f3b80923863877584f1d3be66164aa218ed32841bcb",
-                "sha256:fed35c01a01c6d050f8d67456dad83b5196bf4aff6d88fadd9b70936fb732826"
+                "sha256:0815fb60b23d992a732bd32a7cb9cbcdbbb8faef9f4219fc7570537b2ad72428",
+                "sha256:09c5b5812fdb50ee5ccd3cb2820bd72706e04f42e58245a3f640370aaef17938",
+                "sha256:09f84962dacfee7137b76818476bcd7fcf11626e3e9c20adae2b0fa9c7fe81c3",
+                "sha256:0c50a5d81a4b5583b7fef4ec084fab919a06ad2e7e01eefd778f2a9bfd3f6b19",
+                "sha256:0c5d817a0738d87868ffaeef1ec2aa312cd99b24ba451f4dc993457468d48216",
+                "sha256:0e6800f64c61cfa914c25560eb885a61623e356c7885775b80eead94f80c178c",
+                "sha256:22dc046fece523ca3a86aac75ac9980016c0ba93d35a586bc8b350a62430f4fc",
+                "sha256:385b55cdf6176961d22390e3d2e7c26ab412f2b7e35d150d0a2964afae0d6662",
+                "sha256:3aa094661e8b4229177eb373b5c7b3aca34699711efa004daebd24bf60fd213b",
+                "sha256:3abc211a2ebdf002b0a430079238b4861ea74fa3f6751f4e584702333ec5b886",
+                "sha256:3e20ad60564e71b7a29894d6d1eebe23c43974d82d2529b37d8f766b3ec3ef1e",
+                "sha256:4083a70e3f90f6e48de37611484f489381f21a2615575c9a5a6ea5d9bf46db71",
+                "sha256:424ef6c3f7631b21a7884e5756f23d2fc5c4d89f05b0c87e4b0cd4495b39748e",
+                "sha256:46eefbb36a062fad859bf56087f1a6782aae2a7e0c6234fb82971290db29a3e2",
+                "sha256:47958e3a8ec64768ef9ab7448bcb1c571d3a8138a90674710af811ef082ae428",
+                "sha256:48260059c3204a1fa948233711045b066f09deaa24fb6213e8fb0fc7264832f7",
+                "sha256:4835b0f5fedbee3a3d6eea48f4e65dffd30b52c078690fa97ddc9fcea1e3b35d",
+                "sha256:48f81a903467dd6665af7b2c3089b2dbe16563a945d7dc88c40c585dcd010f8a",
+                "sha256:4a7431905f3b7177c0a03f4ed7471d3d500e0d109c739b724e4ab4d2f852c961",
+                "sha256:4b963b5594e1e1eaa657bc1007aa2f4d78e3be0b38a0c8524da68b981c82854f",
+                "sha256:4f51f7534c6fb47edbe3524357c05680af96d93d38f6c98a2560f56bfcc171ec",
+                "sha256:51c917e8eea1995d540524674406b9658591ae29beab012f79f817757ce218b5",
+                "sha256:52217d64ca280cec095ca9643b7f028edf5c9866af9125ded452699be04d4440",
+                "sha256:58777d1abd8291c9dd98dc236ece82696cd54039daa0b478bb2ad6cb0c8d4b9a",
+                "sha256:5a67abcf8c646970a48896e23256403397927a4ea0bcf0a0e4bd7c2023f675dd",
+                "sha256:5bae8fd51d16a2712e5ecfc40146f6b3bcb6e3837f345be7f20ecc4a86c61903",
+                "sha256:71a2163e14ad95210d7353fd4ea5f02d474afec897e653e54adce45cf0ee1536",
+                "sha256:72b0cf7240cd26efb589afbcff21ed4f430e8237e6c9ab02f7d7118d9677f278",
+                "sha256:7c12b79c625eb6a73d808c234254bfbd23fae08a7f64bb78236c61f77f30454a",
+                "sha256:8373f35f562a3235a3213a2899da72e7ab2f94e127f88d17e5a9702aa7a7a61d",
+                "sha256:83c0eee24264e715cadef3a4b4cc58b69ec57faa98bf8a49079ceb7345adb767",
+                "sha256:8e2d6c4308a143533a8c9b01616d628de22bc2f9da73ff9dd75f92104597c90f",
+                "sha256:9009bceefe013cbb57663fe3e33b38e695832216b23aa3efb2c81c86b271f0da",
+                "sha256:9e27d4937763c1b4f360bea7f976ea73ccd444f89279a0de2147c8d65fdbf6b0",
+                "sha256:a481ec9bc02c1be56b9d2eff14b00629f679269a10a952134ad6624ff335daa7",
+                "sha256:a73ccbc4f7a57183ec6c3f78e225585ba85f990e93b523359bad83baee349540",
+                "sha256:a968c5572a55ca0acc068c69ffde252bcb0ce79acf857b55a76733eb8e71b2da",
+                "sha256:ae8c79aa3d699b7e48f56e4ee6aececf29a7b01e61db408a6d0e3f3d27f93ee4",
+                "sha256:aeb1e07fab60736583fc17f0bad9ba45b82d4c2099576a936853742e6ff50bd8",
+                "sha256:b476a680c08504c5520d043ee26e8614f71e2fc9abf98fc6de3ad61074684fb6",
+                "sha256:b7f058ba6818cb20dca26ac43c610a2c9846302a34a7f0ac81b0dda0bde15bbf",
+                "sha256:c3b3898087090a03429d14e053af5531075e6db6bdd608fd44fa4eb1021b50f2",
+                "sha256:c758fcba514fded6fc0dc0cd8416f2697af0e1a2e7e13a8be49728820dc51371",
+                "sha256:c88bfb74d343c3214a5482530a112a623704549271006cfb3284daf2dcdda620",
+                "sha256:c9e2be2b9cd3c15980b94371ad71f6c7a415d7b2b88b9ea35a993b4f2a947f11",
+                "sha256:cc032618b4c16b342c98ccfdfd85c5659ba33a9eb1c6e3ca0b2062dc08650f91",
+                "sha256:ce35d280b022766121d09901827973c66b31987047e54062f72ea0a8df8cd267",
+                "sha256:d1845dd5c3a21496a5e7c8d0dbc02ee1f5491a90ae391f0d8ea502e9a2ad9e28",
+                "sha256:d8e0778b2e9a92beef973b050102e7698753c57ef59572b59794580a8990ad95",
+                "sha256:e44313f90365780631597dd59f9a50830a02f038b7e191a44d09a9094683123b",
+                "sha256:ec9afc7641a43d37e7f4c8a6464ec14748aa939443f06754331a30e430a73cf5",
+                "sha256:f4d9e8c8da9ea4bd3d72122e2491bfee798ba1f498abf680a508f78eb49d742b",
+                "sha256:f868103adeb61dd42330c2e85e1c0cccbc9a0b3f53fd84299981c9af99f95da7",
+                "sha256:fe355dd01d2310ddbcdcf903bde451ca4b22cdcc2ea3c36de34997578ee3b1e0"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.46.0"
+            "version": "==1.46.1"
         },
         "grpcio-status": {
             "hashes": [
-                "sha256:3febc0ea7f535a4a58a9b45da60cf204138db75b5696b184670e5d770e7d0128",
-                "sha256:fe80131b83724e7f9818eaa54a49906348ca8d1f636b6331de2fc19a9cac3cb1"
+                "sha256:700ad7bdc2da6b1d873ae9abffd957b3df6b74c8ca4b34c50bf1b062ae10a620",
+                "sha256:95adb6ef4e2e605ad4832043e83c18e525eb39a81a1308380d844951df63542c"
             ],
-            "version": "==1.46.0"
+            "version": "==1.46.1"
         },
         "hologram": {
             "hashes": [
@@ -711,11 +711,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
-                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
             "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.8"
+            "version": "==3.0.9"
         },
         "pyrsistent": {
             "hashes": [
@@ -919,11 +919,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:26ead7d1f93efc0f8c804d9fafafbe4a44b179580a7105754b245155f9af05a8",
-                "sha256:47c7b0c0f8fc10eec4cf1e71c6fdadf8decaa74ffa087e68cd1c20db7ad6a592"
+                "sha256:5534570b9980fc650d45c62877ff603c7aaaf24893371708736cc016bd221c3c",
+                "sha256:ca6ba73b7fd5f734ae70ece8c4c1f7062b07f3352f6428f6277e27c8f5c64237"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==62.1.0"
+            "version": "==62.2.0"
         },
         "six": {
             "hashes": [
@@ -1009,7 +1009,7 @@
                 "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                 "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'",
             "version": "==1.26.9"
         },
         "werkzeug": {

--- a/analyses/archive/assist_type_test.sql
+++ b/analyses/archive/assist_type_test.sql
@@ -9,7 +9,7 @@ with test as (
   left join`nhl-breakouts.dbt_dom.d_schedule` as schedule on schedule.game_id = plays.game_id
   left join `nhl-breakouts.dbt_dom.d_seasons` as season on season.season_id = schedule.season_id
   where 1 = 1
-    and schedule.game_type = 'R'
+    and schedule.game_type = '02'
     and plays.event_type = 'GOAL'
     and plays.player_role = 'ASSIST'
     and plays.play_period_type <> 'SHOOTOUT'

--- a/models/analytics/core/f_player_season.sql
+++ b/models/analytics/core/f_player_season.sql
@@ -73,24 +73,6 @@ player_season as (
         , sum(case when plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_missed
         , sum(case when plays.event_type = "SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_saved
         , sum(case when plays.event_type = "GOAL" and plays.player_role = "SCORER" then 1 else 0 end) as shots_scored
-        -- shot types by result
-        /**----- shot-blocked
-        , sum(case when plays.event_secondary_type = "BACKHAND" and plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_backhand_blocked
-        , sum(case when plays.event_secondary_type = "DEFLECTED" and plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER"then 1 else 0 end) as shots_deflected_blocked
-        , sum(case when plays.event_secondary_type = "SLAP SHOT" and plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_slapshot_blocked
-        , sum(case when plays.event_secondary_type = "SNAP SHOT" and plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_snapshot_blocked
-        , sum(case when plays.event_secondary_type = "TIP-IN" and plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_tipin_blocked
-        , sum(case when plays.event_secondary_type = "WRAP-AROUND" and plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_wraparound_blocked
-        , sum(case when plays.event_secondary_type = "WRIST SHOT" and plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_wristshot_blocked
-        ----- shot-missed
-        , sum(case when plays.event_secondary_type = "BACKHAND" and plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_backhand_missed
-        , sum(case when plays.event_secondary_type = "DEFLECTED" and plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER"then 1 else 0 end) as shots_deflected_missed
-        , sum(case when plays.event_secondary_type = "SLAP SHOT" and plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_slapshot_missed
-        , sum(case when plays.event_secondary_type = "SNAP SHOT" and plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_snapshot_missed
-        , sum(case when plays.event_secondary_type = "TIP-IN" and plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_tipin_missed
-        , sum(case when plays.event_secondary_type = "WRAP-AROUND" and plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_wraparound_missed
-        , sum(case when plays.event_secondary_type = "WRIST SHOT" and plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_wristshot_missed
-        **/
         ----- shot-saved
         , sum(case when plays.event_secondary_type = "BACKHAND" and plays.event_type = "SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_backhand_saved
         , sum(case when plays.event_secondary_type = "DEFLECTED" and plays.event_type = "SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_deflected_saved

--- a/models/analytics/core/f_player_season.sql
+++ b/models/analytics/core/f_player_season.sql
@@ -53,27 +53,33 @@ player_season as (
 )
 
 -- at the player-season level, get the number of missed shots and blocked shots by each shooter
-, player_shots as (
+, player_stats as (
     select
         plays.player_id
         , season.season_id
         , max(plays.event_description) as example_eventdescription
+        -- shot types
         , sum(case when plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_blocked
         , sum(case when plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_missed
         , sum(case when plays.event_type = "SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_saved
         , sum(case when plays.event_type = "GOAL" and plays.player_role = "SCORER" then 1 else 0 end) as shots_scored
+        -- goal types
         , sum(case when plays.last_goal_game_winning = 1 and plays.player_role = "SCORER" then 1 else 0 end) as goals_gamewinning
         , sum(case when (plays.home_result_of_play = 'Chase goal' or plays.away_result_of_play = 'Chase goal') and plays.player_role = "SCORER" then 1 else 0 end) as goals_chasegoal
         , sum(case when (plays.home_result_of_play = 'Tying goal scored' or plays.away_result_of_play = 'Tying goal scored') and plays.player_role = "SCORER" then 1 else 0 end) as goals_gametying
         , sum(case when (plays.home_result_of_play = 'Go-ahead goal scored' or plays.away_result_of_play = 'Go-ahead goal scored') and plays.player_role = "SCORER" then 1 else 0 end) as goals_goahead
         , sum(case when (plays.home_result_of_play = 'Buffer goal' or plays.away_result_of_play = 'Buffer goal') and plays.player_role = "SCORER" then 1 else 0 end) as goals_buffergoal
+        -- assist types
+        , sum(case when plays.player_primary_assist = true and plays.player_role = "ASSIST" and plays.event_type = "GOAL" then 1 else 0 end) as assists_primary
+        , sum(case when plays.player_secondary_assist = true and plays.player_role = "ASSIST" and plays.event_type = "GOAL" then 1 else 0 end) as assists_secondary
     from {{ ref('f_plays') }} as plays
     left join {{ ref('d_schedule') }} as schedule on schedule.game_id = plays.game_id
     left join {{ ref('d_seasons') }} as season on season.season_id = schedule.season_id
     where 1 = 1
-        and plays.player_role in ("SHOOTER", "SCORER")
+        and plays.player_role in ("SHOOTER", "SCORER", "ASSIST")
         and plays.event_type in ("BLOCKED_SHOT", "MISSED_SHOT", "SHOT", "GOAL")
         and plays.play_period_type <> 'SHOOTOUT'
+        and schedule.game_type = 'R'
     group by
         plays.player_id
         , season.season_id
@@ -102,21 +108,23 @@ select
     -- Goal-scoring skater events (Goals, Assists, Points)
     , player_season.goals
     , (player_season.goals / player_season.boxscore_games) as goals_pergame
-    , player_shots.goals_gamewinning
-    , player_shots.goals_chasegoal
-    , player_shots.goals_gametying
-    , player_shots.goals_goahead
-    , player_shots.goals_buffergoal
+    , player_stats.goals_gamewinning
+    , player_stats.goals_chasegoal
+    , player_stats.goals_gametying
+    , player_stats.goals_goahead
+    , player_stats.goals_buffergoal
     , player_season.assists
+    , player_stats.assists_primary
+    , player_stats.assists_secondary
     , player_season.goals + player_season.assists as points
     , ((player_season.goals + player_season.assists) / player_season.boxscore_games) as points_pergame
     -- Shooting skater events
     , player_season.shots
     , case when player_season.shots < 1 then 0 else round((player_season.goals / player_season.shots), 2) end as pcnt_shooting
-    , player_shots.shots_blocked
-    , player_shots.shots_missed
-    , player_shots.shots_saved
-    , player_shots.shots_scored
+    , player_stats.shots_blocked
+    , player_stats.shots_missed
+    , player_stats.shots_saved
+    , player_stats.shots_scored
     -- Other skater events
     , player_season.faceoff_wins
     , player_season.faceoff_taken
@@ -142,6 +150,6 @@ select
 --,player_season.wins
 --,player_season.losses
 from player_season
-left join player_shots on player_season.player_id = player_shots.player_id and player_season.season_id = player_shots.season_id
+left join player_stats on player_season.player_id = player_stats.player_id and player_season.season_id = player_stats.season_id
 order by
     player_season.goals desc

--- a/models/analytics/core/f_player_season.sql
+++ b/models/analytics/core/f_player_season.sql
@@ -61,7 +61,6 @@ player_season as (
         , season.season_id
         , max(plays.event_description) as example_eventdescription
         -- shot types
-<<<<<<< HEAD
         , sum(case when plays.event_secondary_type = "BACKHAND" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_backhand_all
         , sum(case when plays.event_secondary_type = "DEFLECTED" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_deflected_all
         , sum(case when plays.event_secondary_type = "SLAP SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_slapshot_all
@@ -70,13 +69,10 @@ player_season as (
         , sum(case when plays.event_secondary_type = "WRAP-AROUND" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_wraparound_all
         , sum(case when plays.event_secondary_type = "WRIST SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_wristshot_all
         -- shot results
-=======
->>>>>>> f8d41389fe2cc8011112fd641c1fbab6e4537933
         , sum(case when plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_blocked
         , sum(case when plays.event_type = "MISSED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_missed
         , sum(case when plays.event_type = "SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_saved
         , sum(case when plays.event_type = "GOAL" and plays.player_role = "SCORER" then 1 else 0 end) as shots_scored
-<<<<<<< HEAD
         -- shot types by result
         /**----- shot-blocked
         , sum(case when plays.event_secondary_type = "BACKHAND" and plays.event_type = "BLOCKED_SHOT" and plays.player_role = "SHOOTER" then 1 else 0 end) as shots_backhand_blocked
@@ -111,8 +107,6 @@ player_season as (
         , sum(case when plays.event_secondary_type = "TIP-IN" and plays.player_role = "SCORER" then 1 else 0 end) as shots_tipin_goal
         , sum(case when plays.event_secondary_type = "WRAP-AROUND" and plays.player_role = "SCORER" then 1 else 0 end) as shots_wraparound_goal
         , sum(case when plays.event_secondary_type = "WRIST SHOT" and plays.player_role = "SCORER" then 1 else 0 end) as shots_wristshot_goal
-=======
->>>>>>> f8d41389fe2cc8011112fd641c1fbab6e4537933
         -- goal types
         , sum(case when plays.last_goal_game_winning = 1 and plays.player_role = "SCORER" then 1 else 0 end) as goals_gamewinning
         , sum(case when (plays.home_result_of_play = 'Chase goal' or plays.away_result_of_play = 'Chase goal') and plays.player_role = "SCORER" then 1 else 0 end) as goals_chasegoal
@@ -129,11 +123,7 @@ player_season as (
         and plays.player_role in ("SHOOTER", "SCORER", "ASSIST")
         and plays.event_type in ("BLOCKED_SHOT", "MISSED_SHOT", "SHOT", "GOAL")
         and plays.play_period_type <> 'SHOOTOUT'
-<<<<<<< HEAD
         and schedule.game_type = '02'
-=======
-        and schedule.game_type = 'R'
->>>>>>> f8d41389fe2cc8011112fd641c1fbab6e4537933
     group by
         plays.player_id
         , season.season_id

--- a/models/analytics/core/f_player_season.sql
+++ b/models/analytics/core/f_player_season.sql
@@ -41,7 +41,7 @@ player_season as (
 
     where 1 = 1
         and schedule.game_type = '02' --regular season only
-        and scratches.player_id is null -- remove scractches, should be same as `and bp.time_on_ice is not null`
+        and scratches.player_id is null -- remove scratches, should be same as `and bp.time_on_ice is not null`
     group by
         bp.player_id
         , player.full_name

--- a/models/analytics/core/f_player_season.yml
+++ b/models/analytics/core/f_player_season.yml
@@ -82,12 +82,12 @@ models:
       - name: points_pergame
         description: The number of points scored in the regular season divided by the number of games played
 
-      ## Shooting skater stats
-      - name: shots
-        description: Number of shots taken
+      ## Skater shot results
+      - name: shots_all
+        description: The total number of shots taken (missed + blocked + on-goal)
 
-      - name: pcnt_shooting
-        description: The percent of shots on goal that were goals (e.g. 10% shooting means 1 out of 10 shots on net were goals)
+      - name: shots_ongoal
+        description: The total number of shots taken on-goal (saved or goals)
 
       - name: shots_blocked
         description: The number of shots taken that were blocked (e.g. shot taken that hits an opposing team defencemen)
@@ -100,6 +100,119 @@ models:
 
       - name: shots_scored
         description: The number of shots taken that converted as goals
+
+      ## Skater shot types
+      - name: shots_backhand_all
+        description: The number of backhand shots that were either saved or were goals (no misses or blocks)
+
+      - name: shots_deflected_all
+        description: The number of deflected shots that were either saved or were goals (no misses or blocks)
+
+      - name: shots_slapshot_all
+        description: The number of slapshot shots that were either saved or were goals (no misses or blocks)
+
+      - name: shots_snapshot_all
+        description: The number of snapshot shots that were either saved or were goals (no misses or blocks)
+
+      - name: shots_tipin_all
+        description: The number of tip-in shots that were either saved or were goals (no misses or blocks)
+
+      - name: shots_wraparound_all
+        description: The number of wraparound shots that were either saved or were goals (no misses or blocks)
+
+      - name: shots_wristshot_all
+        description: The number of wristshot shots that were either saved or were goals (no misses or blocks)
+
+      ## Skater shot results by type (shot-saved)
+      - name: shots_backhand_saved
+        description: The number of backhand shots that were saved
+
+      - name: shots_deflected_saved
+        description: The number of deflected shots that were saved
+
+      - name: shots_slapshot_saved
+        description: The number of slapshot shots that were saved
+
+      - name: shots_snapshot_saved
+        description: The number of snapshot shots that were saved
+
+      - name: shots_tipin_saved
+        description: The number of tip-in shots that were saved
+
+      - name: shots_wraparound_saved
+        description: The number of wrap-around shots that were saved
+
+      - name: shots_wristshot_saved
+        description: The number of wristshot shots that were saved
+
+      ## Skater shot results by type (shot-goal)
+      - name: shots_backhand_goal
+        description: The number of backhand shots that were goals
+
+      - name: shots_deflected_goal
+        description: The number of deflected shots that were goals
+
+      - name: shots_slapshot_goal
+        description: The number of slapshot shots that were goals
+
+      - name: shots_snapshot_goal
+        description: The number of snapshot shots that were goals
+
+      - name: shots_tipin_goal
+        description: The number of tip-in shots that were goals
+
+      - name: shots_wraparound_goal
+        description: The number of wrap-around shots that were goals
+
+      - name: shots_wristshot_goal
+        description: The number of wristshot shots that were goals
+
+      ## Skater shot results by type (shot-conversion)
+      - name: pcnt_shooting_all
+        description: The percent of all shots (blocked + misses + on-goal) that were goals (e.g. 10% shooting means 1 out of 10 shots taken were goals)
+
+      - name: pcnt_shooting_ongoal
+        description: The percent of all shots on goal that were goals (e.g. 10% shooting means 1 out of 10 shots on net were goals)
+
+      - name: pcnt_shooting_backhand
+        description: The percent of all backhand shots on goal that were goals (e.g. 10% shooting means 1 out of 10 backhand shots on net were goals)
+
+      - name: pcnt_shooting_deflected
+        description: The percent of all deflected shots on goal that were goals (e.g. 10% shooting means 1 out of 10 deflected shots on net were goals)
+
+      - name: pcnt_shooting_slapshot
+        description: The percent of all slapshot shots on goal that were goals (e.g. 10% shooting means 1 out of 10 slapshot shots on net were goals)
+
+      - name: pcnt_shooting_snapshot
+        description: The percent of all snapshot shots on goal that were goals (e.g. 10% shooting means 1 out of 10 snapshot shots on net were goals)
+
+      - name: pcnt_shooting_tipin
+        description: The percent of all tip-in shots on goal that were goals (e.g. 10% shooting means 1 out of 10 tip-in shots on net were goals)
+
+      - name: pcnt_shooting_wraparound
+        description: The percent of all wrap-around shots on goal that were goals (e.g. 10% shooting means 1 out of 10 wrap-around shots on net were goals)
+      
+      - name: pcnt_shooting_wristshot
+        description: The percent of all wristshot shots on goal that were goals (e.g. 10% shooting means 1 out of 10 wristshot shots on net were goals)
+
+      ## delete these start ##
+      - name: shots
+        description: Number of shots taken
+
+
+      - name: shots_blocked
+        description: The number of shots taken that were blocked (e.g. shot taken that hits an opposing team defencemen)
+
+      - name: shots_missed
+        description: The number of shots taken that were missed (e.g. shot taken that missees the net)
+
+      - name: shots_saved
+        description: The number of shots taken that were on target but were saved
+
+      - name: shots_scored
+        description: The number of shots taken that converted as goals
+
+      ## delete these end ##
 
       ## Other skater stats
       - name: faceoff_wins

--- a/models/analytics/core/f_player_season.yml
+++ b/models/analytics/core/f_player_season.yml
@@ -67,6 +67,12 @@ models:
       - name: goals_buffergoal
         description: The number of goals scored while the team was ahead by at least 1 goal
 
+      - name: assists_primary
+        description: The number of primary assists on goals in the regular season
+
+      - name: assists_secondary
+        description: The number of secondary assists on goals in the regular season
+
       - name: assists
         description: The number of assists on goals made in the regular season
 

--- a/models/analytics/intermediate/d_schedule.sql
+++ b/models/analytics/intermediate/d_schedule.sql
@@ -11,8 +11,8 @@ select
 
     /* Properties */
     , game_number
-    , url
     , game_type
+    , game_type_description
     , game_date
     , abstract_game_state
     , coded_game_state
@@ -36,6 +36,7 @@ select
     , venue_name
     , venue_url
     , content_url
+    , url
     , extracted_at
     , loaded_at
 from

--- a/models/analytics/intermediate/d_schedule.yml
+++ b/models/analytics/intermediate/d_schedule.yml
@@ -42,11 +42,11 @@ models:
       - name: game_number
         description: Four digit number that is unique to a game in the context of a season (e.g. 0002)
 
-      - name: url
-        description: URL endpoint for schedule
-
       - name: game_type
-        description: Code for the type of game (e.g. R = regular season)
+        description: Code for the type of game, which is retrieved by extracting the the 5th and 6th position from the game_id (e.g. 02 = regular season game)
+
+      - name: game_type_description
+        description: Description for the type of game played, enhancing game_type (e.g. Pre-season, Regular, Playoffs, All-star)
 
       - name: game_date
         description: Date that the game takes place (e.g. 2021-01-14)
@@ -116,6 +116,9 @@ models:
 
       - name: content_url
         description: URL endpoint for the content
+
+      - name: url
+        description: URL endpoint for schedule
 
       - name: extracted_at
         description: Timestamp that the data was retrieved

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -18,6 +18,9 @@ select
     , event_type
     , event_code
     , event_description
+    , event_secondary_type
+    , penalty_severity
+    , penalty_minutes
     , play_x_coordinate
     , play_y_coordinate
     , play_period

--- a/models/analytics/intermediate/f_plays.yml
+++ b/models/analytics/intermediate/f_plays.yml
@@ -36,8 +36,8 @@ models:
 
       - name: team_id
         description: Foreign key that maps to an NHL team ID
-        tests:
-          - not_null
+        #tests:
+        #  - not_null
 
       # Properties
       - name: player_full_name
@@ -63,6 +63,15 @@ models:
 
       - name: event_description
         description: Long description of the event (repeated for all the player's involved in the event)
+
+      - name: event_secondary_type
+        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+
+      - name: penalty_severity
+        description: If the play in question was a penalty, this column will describe its severity (e.g. MINOR, MAJOR), else null
+
+      - name: penalty_minutes
+        description: If the play in question was a penalty, this column will return the number of minutes the penalty was assessed for, else null
 
       - name: play_x_coordinate
         description: The x-coordinate of where the event took place on the ice

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -16,6 +16,9 @@ live_plays as (
         , offset as player_index -- noqa: disable=L027
         , boxscore_player.team_id as team_id -- noqa: enable=L027
         , upper(players.playertype) as player_role
+        , upper(live_plays.result.secondarytype) as event_secondary_type
+        , upper(live_plays.result.penaltyseverity) as penalty_severity
+        , live_plays.result.penaltyminutes as penalty_minutes
         -- Was the play/player in question home or away?
         , case
             when live_plays.team.id = schedule.away_team_id
@@ -198,6 +201,9 @@ live_plays as (
         , bp.event_type
         , bp.event_code
         , bp.event_description
+        , bp.event_secondary_type
+        , bp.penalty_severity
+        , bp.penalty_minutes
         , bp.play_x_coordinate
         , bp.play_y_coordinate
         , bp.play_period
@@ -422,6 +428,9 @@ select
     , event_type
     , event_code
     , event_description
+    , event_secondary_type
+    , penalty_severity
+    , penalty_minutes
     , play_x_coordinate
     , play_y_coordinate
     , play_period

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -8,7 +8,7 @@ live_plays as (
 -- CTE2 Play-level information (each row is a player's involvement in a play)
 , cte_base_plays as (
     select
-        {{ dbt_utils.surrogate_key(['live_plays.gameid', 'live_plays.about.eventidx', 'players.player.id']) }} as stg_nhl__live_plays_id
+        {{ dbt_utils.surrogate_key(['live_plays.gameid', 'live_plays.about.eventidx', 'players.player.id', 'players.playertype']) }} as stg_nhl__live_plays_id
         , live_plays.gameid as game_id
         , live_plays.about.eventid as event_id
         , players.player.id as player_id

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -297,11 +297,6 @@ live_plays as (
         end as goals_away_lag
 
     from cte_base_plays as bp
-
-    order by
-        bp.game_id
-        , (bp.play_minutes_elapsed * 60) + (bp.play_seconds_elapsed)
-        , event_idx
 )
 
 -- CTE to determine the state of the game as a result of the play

--- a/models/staging/stg_nhl__live_plays.yml
+++ b/models/staging/stg_nhl__live_plays.yml
@@ -57,6 +57,15 @@ models:
       - name: event_description
         description: Long description of the event (repeated for all the player's involved in the event)
 
+      - name: event_secondary_type
+        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+
+      - name: penalty_severity
+        description: If the play in question was a penalty, this column will describe its severity (e.g. MINOR, MAJOR), else null
+
+      - name: penalty_minutes
+        description: If the play in question was a penalty, this column will return the number of minutes the penalty was assessed for, else null
+
       - name: play_x_coordinate
         description: The x-coordinate of where the event took place on the ice
 

--- a/models/staging/stg_nhl__schedule.sql
+++ b/models/staging/stg_nhl__schedule.sql
@@ -11,8 +11,14 @@ select
 
     /* Properties */
     , substr(cast(schedule.gamepk as string), 7, 4) as game_number
-    , schedule.link as url
-    , schedule.gametype as game_type
+    , substr(cast(gamepk as string), 5, 2) as game_type
+    , case
+        when substr(cast(gamepk as string), 5, 2) = '01' then 'Preseason'
+        when substr(cast(gamepk as string), 5, 2) = '02' then 'Regular'
+        when substr(cast(gamepk as string), 5, 2) = '03' then 'Playoffs'
+        when substr(cast(gamepk as string), 5, 2) = '04' then 'All-star'
+        else 'Unknown'
+    end as game_type_description
     , date(schedule.gamedate) as game_date
     , schedule.status.abstractgamestate as abstract_game_state
     , schedule.status.codedgamestate as coded_game_state
@@ -36,6 +42,7 @@ select
     , schedule.venue.name as venue_name
     , schedule.venue.link as venue_url
     , schedule.content.link as content_url
+    , schedule.link as url
     , schedule._time_extracted as extracted_at
     , schedule._time_loaded as loaded_at
 from {{ source('meltano', 'schedule') }} as schedule

--- a/models/staging/stg_nhl__schedule.yml
+++ b/models/staging/stg_nhl__schedule.yml
@@ -42,11 +42,11 @@ models:
       - name: game_number
         description: Four digit number that is unique to a game in the context of a season (e.g. 0002)
 
-      - name: url
-        description: URL endpoint for schedule
-
       - name: game_type
-        description: Code for the type of game (e.g. R = regular season)
+        description: Code for the type of game, which is retrieved by extracting the the 5th and 6th position from the game_id (e.g. 02 = regular season game)
+
+      - name: game_type_description
+        description: Description for the type of game played, enhancing game_type (e.g. Pre-season, Regular, Playoffs, All-star)
 
       - name: game_date
         description: Date that the game takes place (e.g. 2021-01-14)
@@ -116,6 +116,9 @@ models:
 
       - name: content_url
         description: URL endpoint for the content
+
+      - name: url
+        description: URL endpoint for schedule
 
       - name: extracted_at
         description: Timestamp that the data was retrieved


### PR DESCRIPTION
# Overview
- Modeled and added primary and secondary assists to `f_player_season` and documentation
- Modeled `secondary_type` (new alias = `event_secondary_type`), `penaltySeverity` (`penalty_severity`),  and `penaltyMinutes` (`penalty_minutes`) to `stg_nhl__live_plays`, `f_plays` and their documentation
- Added various shot type features to `f_player_season` using the new `event_secondary_type` feature
- Fixed and enhanced a problem with `game_type` in the `schedule` data, updated documentation

# Changes
- Modeled and added primary and secondary assists to `f_player_season` and documentation
- Modeled `secondary_type` (new alias = `event_secondary_type`), `penaltySeverity` (`penalty_severity`),  and `penaltyMinutes` (`penalty_minutes`) to `stg_nhl__live_plays`, `f_plays` and their documentation
- Added various shot type features to `f_player_season` using the new `event_secondary_type` feature
- Changed `game_type` in `stg_nhl__schedule` and `d_schedule`  (and their documentation) from default value to the 5th and 6th character of the `game_id` 
- Added `game_type_description` n `stg_nhl__schedule` and `d_schedule` (and their documentation) to provide context to `game_type`
- Resolves #39  &  #41 

# Other notes

# Checks
- [x] All models ran successfully
- [x] Changes to models are reflected in the schema.yml
Pick one:
- [x] No test failures OR
- [x] No new test failures, and there is a plan in place to address existing ones
