### PR TITLE
Hotfix/update liveplays

### DIFF
--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -8,7 +8,7 @@ live_plays as (
 -- CTE2 Play-level information (each row is a player's involvement in a play)
 , cte_base_plays as (
     select
-        {{ dbt_utils.surrogate_key(['live_plays.gameid', 'live_plays.about.eventidx', 'players.player.id']) }} as stg_nhl__live_plays_id
+        {{ dbt_utils.surrogate_key(['live_plays.gameid', 'live_plays.about.eventidx', 'players.player.id', 'players.playertype']) }} as stg_nhl__live_plays_id
         , live_plays.gameid as game_id
         , live_plays.about.eventid as event_id
         , players.player.id as player_id


### PR DESCRIPTION
# Overview
Using `gameid` `eventidx` and `playerid` does not guarantee uniqueness across live play IDs. This is because sometimes the same player can be listed twice in the same event when the event type = `PENALTY`

For example:
>Justin Williams Roughing against Tomas Tatar served by Justin Williams

Justin Williams is listed twice, each time with a different `player_role`: PENALTYON and SERVEDBY.

Therefore, we need to add `player_role` as part of the surrogate key for `stg_nhl__live_plays`

# Changes
- _Details about what was changed_

# Other notes
- _Any other things that the reviewer should know about_

# Checks
- [x] All models ran successfully
- [x] Changes to models are reflected in the schema.yml
Pick one:
- [x] No test failures OR
- [ ] No new test failures, and there is a plan in place to address existing ones
