### PR TITLE
Add f_team_season to dbt

### DIFF
--- a/models/analytics/core/f_team_season.sql
+++ b/models/analytics/core/f_team_season.sql
@@ -1,32 +1,34 @@
 with t1 as (
     select
-        bs.*,
-        sch.season_id,
-        sch.game_type_description
-    from {{ ref('f_boxscore_team') }} as bs
-    left join {{ ref('d_schedule') }} as sch
-        on bs.game_id = sch.game_id
+        boxscore.*
+        , schedule.season_id
+        , schedule.game_type_description
+        , schedule.game_type
+    from {{ ref('f_boxscore_team') }} as boxscore
+    left join {{ ref('d_schedule') }} as schedule
+        on boxscore.game_id = schedule.game_id
 )
 
 , team_season as (
     select
-        team_id,
-        team_name,
-        season_id,
-        game_type_description,
-        count(*) as games_played,
-        sum(case when team_winner = 'true' then 1 else 0 end) as wins,
-        sum(ifnull(team_goals, 0)) as team_goals,
-        sum(ifnull(team_goal_differential, 0)) as team_goal_differential,
-        sum(ifnull(team_pim, 0)) as team_pim,
-        sum(ifnull(team_shots, 0)) as team_shots,
-        sum(ifnull(team_powerplay_goals, 0)) as team_powerplay_goals,
-        sum(ifnull(team_hits, 0)) as team_hits,
-        sum(ifnull(team_blocked, 0)) as team_blocked,
-        sum(ifnull(team_takeaways, 0)) as team_takeaways,
-        sum(ifnull(team_giveaways, 0)) as team_giveaways
+        team_id
+        , team_name
+        , season_id
+        , game_type
+        , game_type_description
+        , count(*) as games_played
+        , sum(case when team_winner = 'true' then 1 else 0 end) as wins
+        , sum(ifnull(team_goals, 0)) as team_goals
+        , sum(ifnull(team_goal_differential, 0)) as team_goal_differential
+        , sum(ifnull(team_pim, 0)) as team_pim
+        , sum(ifnull(team_shots, 0)) as team_shots
+        , round(sum(ifnull(team_powerplay_goals, 0)),0) as team_powerplay_goals
+        , sum(ifnull(team_hits, 0)) as team_hits
+        , sum(ifnull(team_blocked, 0)) as team_blocked
+        , sum(ifnull(team_takeaways, 0)) as team_takeaways
+        , sum(ifnull(team_giveaways, 0)) as team_giveaways
     from t1
-    group by 1, 2, 3, 4
+    group by 1, 2, 3, 4, 5
 )
 
 select
@@ -35,8 +37,10 @@ select
     /* Foreign Keys */
     , team_season.team_id
     , team_season.season_id
+    /* Team & Season Properties */
+    , team_season.team_name
+    , team_season.game_type
     , team_season.game_type_description
-    /* Season Properties */
     , games_played
     /* Team Stats */
     , wins
@@ -50,3 +54,4 @@ select
     , team_giveaways
     , team_takeaways
 from team_season
+order by team_season.season_id, team_season.game_type

--- a/models/analytics/core/f_team_season.sql
+++ b/models/analytics/core/f_team_season.sql
@@ -22,7 +22,7 @@ with t1 as (
         , sum(ifnull(team_goal_differential, 0)) as team_goal_differential
         , sum(ifnull(team_pim, 0)) as team_pim
         , sum(ifnull(team_shots, 0)) as team_shots
-        , round(sum(ifnull(team_powerplay_goals, 0)),0) as team_powerplay_goals
+        , round(sum(ifnull(team_powerplay_goals, 0)), 0) as team_powerplay_goals
         , sum(ifnull(team_hits, 0)) as team_hits
         , sum(ifnull(team_blocked, 0)) as team_blocked
         , sum(ifnull(team_takeaways, 0)) as team_takeaways

--- a/models/analytics/core/f_team_season.sql
+++ b/models/analytics/core/f_team_season.sql
@@ -1,34 +1,35 @@
 with t1 as (
-select bs.*,
-  sch.season_id,
-  sch.game_type_description
-from {{ ref('f_boxscore_team') }} as bs
-left join {{ ref('d_schedule') }} as sch
-  on bs.game_id = sch.game_id
+    select
+        bs.*,
+        sch.season_id,
+        sch.game_type_description
+    from {{ ref('f_boxscore_team') }} as bs
+    left join {{ ref('d_schedule') }} as sch
+        on bs.game_id = sch.game_id
 )
 
 , team_season as (
-SELECT
-  team_id,
-  team_name,
-  season_id,
-  game_type_description,
-  count(*) as games_played,
-  SUM(CASE WHEN team_winner = 'true' THEN 1 ELSE 0 END) as wins,
-  sum(ifnull(team_goals, 0)) as team_goals,
-  sum(ifnull(team_goal_differential, 0)) as team_goal_differential,
-  sum(ifnull(team_pim, 0)) as team_pim,
-  sum(ifnull(team_shots, 0)) as team_shots,
-  sum(ifnull(team_powerplay_goals, 0)) as team_powerplay_goals,
-  sum(ifnull(team_hits, 0)) as team_hits,
-  sum(ifnull(team_blocked, 0)) as team_blocked,
-  sum(ifnull(team_takeaways, 0)) as team_takeaways,
-  sum(ifnull(team_giveaways, 0)) as team_giveaways
-FROM t1
-group by 1, 2, 3, 4
+    select
+        team_id,
+        team_name,
+        season_id,
+        game_type_description,
+        count(*) as games_played,
+        sum(case when team_winner = 'true' then 1 else 0 end) as wins,
+        sum(ifnull(team_goals, 0)) as team_goals,
+        sum(ifnull(team_goal_differential, 0)) as team_goal_differential,
+        sum(ifnull(team_pim, 0)) as team_pim,
+        sum(ifnull(team_shots, 0)) as team_shots,
+        sum(ifnull(team_powerplay_goals, 0)) as team_powerplay_goals,
+        sum(ifnull(team_hits, 0)) as team_hits,
+        sum(ifnull(team_blocked, 0)) as team_blocked,
+        sum(ifnull(team_takeaways, 0)) as team_takeaways,
+        sum(ifnull(team_giveaways, 0)) as team_giveaways
+    from t1
+    group by 1, 2, 3, 4
 )
 
-select 
+select
     /* Primary Key */
     {{ dbt_utils.surrogate_key(['team_season.team_id', 'team_season.season_id', 'team_season.game_type_description']) }} as team_season_stage_id
     /* Foreign Keys */

--- a/models/analytics/core/f_team_season.sql
+++ b/models/analytics/core/f_team_season.sql
@@ -1,0 +1,51 @@
+with t1 as (
+select bs.*,
+  sch.season_id,
+  sch.game_type_description
+from {{ ref('f_boxscore_team') }} as bs
+left join {{ ref('d_schedule') }} as sch
+  on bs.game_id = sch.game_id
+)
+
+, team_season as (
+SELECT
+  team_id,
+  team_name,
+  season_id,
+  game_type_description,
+  count(*) as games_played,
+  SUM(CASE WHEN team_winner = 'true' THEN 1 ELSE 0 END) as wins,
+  sum(ifnull(team_goals, 0)) as team_goals,
+  sum(ifnull(team_goal_differential, 0)) as team_goal_differential,
+  sum(ifnull(team_pim, 0)) as team_pim,
+  sum(ifnull(team_shots, 0)) as team_shots,
+  sum(ifnull(team_powerplay_goals, 0)) as team_powerplay_goals,
+  sum(ifnull(team_hits, 0)) as team_hits,
+  sum(ifnull(team_blocked, 0)) as team_blocked,
+  sum(ifnull(team_takeaways, 0)) as team_takeaways,
+  sum(ifnull(team_giveaways, 0)) as team_giveaways
+FROM t1
+group by 1, 2, 3, 4
+)
+
+select 
+    /* Primary Key */
+    {{ dbt_utils.surrogate_key(['team_season.team_id', 'team_season.season_id', 'team_season.game_type_description']) }} as team_season_stage_id
+    /* Foreign Keys */
+    , team_season.team_id
+    , team_season.season_id
+    , team_season.game_type_description
+    /* Season Properties */
+    , games_played
+    /* Team Stats */
+    , wins
+    , team_goals
+    , team_goal_differential
+    , team_pim
+    , team_shots
+    , team_powerplay_goals
+    , team_hits
+    , team_blocked
+    , team_giveaways
+    , team_takeaways
+from team_season

--- a/models/analytics/core/f_team_season.yml
+++ b/models/analytics/core/f_team_season.yml
@@ -18,10 +18,16 @@ models:
       - name: season_id
         description: Foreign key that maps to an NHL season (e.g. "20172018")
 
+      # Team & Season Properties
+      - name: team_name
+        description: Full name of the NHL team (e.g. Vancouver Canucks)
+
+      - name: game_type
+        description: Code for the type of game, which is retrieved by extracting the the 5th and 6th position from the game_id (e.g. 02 = regular season game)
+
       - name: game_type_description
         description: Foreign key that maps to an NHL season stage (e.g. "Playoffs")
 
-      # Season Properties
       - name: games_played
         description: The number of games played in season and stage by the team
 
@@ -49,7 +55,7 @@ models:
 
       - name: team_blocked
         description: The number of shot attempts blocked by the team
-      
+
       - name: team_giveaways
         description: The number of giveaways by the team
 

--- a/models/analytics/core/f_team_season.yml
+++ b/models/analytics/core/f_team_season.yml
@@ -1,0 +1,57 @@
+version: 2
+
+models:
+  - name: f_team_season
+    description: Model-ready, feature rich dataset at the team-season-stage level of granularity
+    columns:
+      # Primary Key
+      - name: team_season_stage_id
+        description: Unique identifier for a team's summarized activity in an NHL season and stage (player_id + season_id + game_type_description)
+        tests:
+          - unique
+          - not_null
+
+      # Foreign Keys
+      - name: team_id
+        description: Foreign key that maps to an NHL team ID
+
+      - name: season_id
+        description: Foreign key that maps to an NHL season (e.g. "20172018")
+
+      - name: game_type_description
+        description: Foreign key that maps to an NHL season stage (e.g. "Playoffs")
+
+      # Season Properties
+      - name: games_played
+        description: The number of games played in season and stage by the team
+
+      # Team Stats
+      - name: wins
+        description: Games won by team
+
+      - name: team_goals
+        description: Goals scored by team
+
+      - name: team_goal_differential
+        description: Team goal differential
+
+      - name: team_pim
+        description: Penalty minutes accrued by team
+
+      - name: team_shots
+        description: Shots on goal by team
+
+      - name: team_powerplay_goals
+        description: The number of power play goals scored by the team
+
+      - name: team_hits
+        description: The number of hits delivered by the team
+
+      - name: team_blocked
+        description: The number of shot attempts blocked by the team
+      
+      - name: team_giveaways
+        description: The number of giveaways by the team
+
+      - name: team_takeaways
+        description: The number of takeaways by the team


### PR DESCRIPTION
# Overview
- Summary table at the team level to mimic f_player_season at the team level
- [issue #54](https://github.com/bicks-bapa-roob/dbt-nhl-breakouts/issues/54)

# Changes
- New table with team level statistics

# Other notes

# Checks
- [ ] All models ran successfully
- [ ] Changes to models are reflected in the schema.yml
Pick one:
- [ ] No test failures OR
- [ ] No new test failures, and there is a plan in place to address existing ones
