### PR TITLE
Feature engineering shot rebounds

### DIFF
--- a/models/analytics/core/f_player_season.yml
+++ b/models/analytics/core/f_player_season.yml
@@ -161,6 +161,9 @@ models:
       - name: shots_wristshot_all
         description: The number of wristshot shots that were either saved or were goals (no misses or blocks)
 
+      - name: shots_rebound_all
+        description: The number of rebounds (shot taken within 2 seconds of previous if taken by same team and same period) that were either saved or were goals (no misses or blocks)
+
       ## Skater shot results by type (shot-saved)
       - name: shots_backhand_saved
         description: The number of backhand shots that were saved
@@ -183,6 +186,9 @@ models:
       - name: shots_wristshot_saved
         description: The number of wristshot shots that were saved
 
+      - name: shots_rebound_saved
+        description: The number of rebounds (shot taken within 2 seconds of previous if taken by same team and same period) that were saved
+
       ## Skater shot results by type (shot-goal)
       - name: shots_backhand_goal
         description: The number of backhand shots that were goals
@@ -204,6 +210,10 @@ models:
 
       - name: shots_wristshot_goal
         description: The number of wristshot shots that were goals
+
+      - name: shots_rebound_goal
+        description: The number of rebounds (shot taken within 2 seconds of previous if taken by same team and same period) that were goals
+
 
       - name: pcnt_ff
         description: Fenwick for percentage (while on the ice) = Fenwick shots for / (Fenwick shots for + Fenwick shots against)
@@ -244,6 +254,9 @@ models:
 
       - name: pcnt_shooting_wristshot
         description: The percent of all wristshot shots on goal that were goals (e.g. 10% shooting means 1 out of 10 wristshot shots on net were goals)
+
+      - name: pcnt_shooting_rebound
+        description: The percent of all rebound shots on goal that were goals (e.g. 10% shooting means 1 out of 10 rebound shots on net were goals)
 
       ## Other skater stats
       - name: faceoff_wins

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -83,7 +83,7 @@ select
     -- rebounds: if the last shot was take by the same team in the same period, and the time elapsed between shots was between 0 - 2 seconds, then 1 else 0
     , case
         when plays.last_shot_saved_shot_ind = 1
-            and last_play_period = play_period
+            and plays.last_play_period = plays.play_period
             and lower(plays.last_play_event_type) in ('blocked_shot', 'missed_shot', 'shot', 'goal')
             and (plays.play_total_seconds_elapsed - plays.last_shot_total_seconds_elapsed) <= 2
             then 1

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -15,10 +15,14 @@ select
     , plays.player_secondary_assist
     , plays.player_role
     , plays.player_role_team
-    , plays.event_type
     , plays.event_code
-    , plays.event_description
+    , plays.event_type
     , plays.event_secondary_type
+    , plays.event_description
+    , plays.last_play_event_type
+    , plays.last_play_event_secondary_type
+    , plays.last_play_event_description
+    , plays.last_play_period
     , plays.penalty_severity
     , plays.penalty_minutes
     , plays.play_x_coordinate
@@ -79,6 +83,8 @@ select
     -- rebounds: if the last shot was take by the same team in the same period, and the time elapsed between shots was between 0 - 2 seconds, then 1 else 0
     , case
         when plays.last_shot_saved_shot_ind = 1
+            and last_play_period = play_period
+            and lower(plays.last_play_event_type) in ('blocked_shot', 'missed_shot', 'shot', 'goal')
             and (plays.play_total_seconds_elapsed - plays.last_shot_total_seconds_elapsed) <= 2
             then 1
         else 0

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -61,6 +61,28 @@ select
     , plays.goal_difference_lag
     , plays.winning_team_lag
     , plays.game_state_lag
+    , plays.last_shot_event_idx
+    , plays.last_shot_team_id
+    , plays.last_shot_period
+    , plays.last_shot_total_seconds_elapsed
+    , plays.last_shot_event_type
+    , plays.last_shot_event_secondary_type
+    , plays.last_shot_x_coordinate
+    , plays.last_shot_y_coordinate
+    , plays.last_shot_saved_shot_ind
+    -- seconds since last shot: if the last shot was take by the same team in the same period, get the time elapsed between shots
+    , case
+        when plays.last_shot_saved_shot_ind = 1
+            then play_total_seconds_elapsed - last_shot_total_seconds_elapsed
+        else 0
+    end as last_shot_seconds
+    -- rebounds: if the last shot was take by the same team in the same period, and the time elapsed between shots was between 0 - 2 seconds, then 1 else 0
+    , case
+        when plays.last_shot_saved_shot_ind = 1
+            and (play_total_seconds_elapsed - last_shot_total_seconds_elapsed) <= 2
+            then 1
+        else 0
+    end as last_shot_rebound_ind
 
     /* Shift properties */
     , shifts.shift_id

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -73,13 +73,13 @@ select
     -- seconds since last shot: if the last shot was take by the same team in the same period, get the time elapsed between shots
     , case
         when plays.last_shot_saved_shot_ind = 1
-            then play_total_seconds_elapsed - last_shot_total_seconds_elapsed
+            then (plays.play_total_seconds_elapsed - plays.last_shot_total_seconds_elapsed)
         else 0
     end as last_shot_seconds
     -- rebounds: if the last shot was take by the same team in the same period, and the time elapsed between shots was between 0 - 2 seconds, then 1 else 0
     , case
         when plays.last_shot_saved_shot_ind = 1
-            and (play_total_seconds_elapsed - last_shot_total_seconds_elapsed) <= 2
+            and (plays.play_total_seconds_elapsed - plays.last_shot_total_seconds_elapsed) <= 2
             then 1
         else 0
     end as last_shot_rebound_ind

--- a/models/analytics/intermediate/f_plays.yml
+++ b/models/analytics/intermediate/f_plays.yml
@@ -280,5 +280,36 @@ models:
       - name: away_goalie_on_ice
         description: The number of away goalies on the ice (1 or 0)
 
+      - name: last_shot_event_idx
+        description: Looks back to the last (previous) shot, returns the event sequence (e.g. 1 = first event, 2 = second event)
 
+      - name: last_shot_team_id
+        description: Looks back to the last (previous) shot, returns the team_id for the shoot
+
+      - name: last_shot_period
+        description: Looks back to the last (previous) shot, returns the period
+
+      - name: last_shot_total_seconds_elapsed
+        description: Looks back to the last (previous) shot, returns the total seconds elapsed
+
+      - name: last_shot_event_type
+        description: Looks back to the last (previous) shot, returns the event type (e.g. 'GOAL', 'MISSED_SHOT', 'SHOT', 'GOAL')
+
+      - name: last_shot_event_secondary_type
+        description: Looks back to the last (previous) shot, returns the event_secondary_type (e.g. basically, shot type)
+
+      - name: last_shot_x_coordinate
+        description: Looks back to the last (previous) shot, returns the x_coordinate
+
+      - name: last_shot_y_coordinate
+        description: Looks back to the last (previous) shot, returns the y_coordinate
+
+      - name: last_shot_saved_shot_ind
+        description: Looks back to the last (previous) shot, returns a '1' if the shot was taken by same team, in the same period, and was on target but did not result in a goal
+
+      - name: last_shot_seconds
+        description: Seconds since last shot - returns the time elapsed between shots if the shot was taken by same team, in the same period, and was on target but did not result in a goal
+
+      - name: last_shot_rebound_ind
+        description: Rebounds indicator - returns a '1' if the shot was taken by same team, in the same period, was on target but did not result in a goal, and the time elapsed between shots was between 0 - 2 seconds
 

--- a/models/analytics/intermediate/f_plays.yml
+++ b/models/analytics/intermediate/f_plays.yml
@@ -55,17 +55,29 @@ models:
       - name: player_role_team
         description: The home / away status of the player's team
 
+      - name: event_code
+        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+
       - name: event_type
         description: Short description of the event type
 
-      - name: event_code
-        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+      - name: event_secondary_type
+        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
 
       - name: event_description
         description: Long description of the event (repeated for all the player's involved in the event)
 
-      - name: event_secondary_type
-        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+      - name: last_play_event_type
+        description: Short description of the previous play's event type
+
+      - name: last_play_event_secondary_type
+        description: If the previous play's event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+
+      - name: last_play_event_description
+        description: Long description of the previous play's event (repeated for all the player's involved in the event)
+
+      - name: last_play_period
+        description: The period in which the previous play's event occured (e.g. 3)
 
       - name: penalty_severity
         description: If the play in question was a penalty, this column will describe its severity (e.g. MINOR, MAJOR), else null

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -201,6 +201,10 @@ live_plays as (
         , bp.event_code
         , bp.event_description
         , bp.event_secondary_type
+        , lag(bp.event_type) over (partition by game_id order by event_idx) as last_play_event_type
+        , lag(bp.event_secondary_type) over (partition by game_id order by event_idx) as last_play_event_secondary_type
+        , lag(bp.event_description) over (partition by game_id order by event_idx) as last_play_event_description
+        , ifnull(lag(bp.play_period) over (partition by game_id order by event_idx), play_period) as last_play_period
         , bp.penalty_severity
         , bp.penalty_minutes
         , bp.play_x_coordinate
@@ -461,10 +465,14 @@ select
     , gs.player_secondary_assist
     , gs.player_role
     , gs.player_role_team
-    , gs.event_type
     , gs.event_code
-    , gs.event_description
+    , gs.event_type
     , gs.event_secondary_type
+    , gs.event_description
+    , gs.last_play_event_type
+    , gs.last_play_event_secondary_type
+    , gs.last_play_event_description
+    , gs.last_play_period
     , gs.penalty_severity
     , gs.penalty_minutes
     , gs.play_x_coordinate

--- a/models/staging/stg_nhl__live_plays.yml
+++ b/models/staging/stg_nhl__live_plays.yml
@@ -48,17 +48,29 @@ models:
       - name: player_role_team
         description: The home / away status of the player's team
 
+      - name: event_code
+        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+
       - name: event_type
         description: Short description of the event type
 
-      - name: event_code
-        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+      - name: event_secondary_type
+        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
 
       - name: event_description
         description: Long description of the event (repeated for all the player's involved in the event)
 
-      - name: event_secondary_type
-        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+      - name: last_play_event_type
+        description: Short description of the previous play's event type
+
+      - name: last_play_event_secondary_type
+        description: If the previous play's event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+
+      - name: last_play_event_description
+        description: Long description of the previous play's event (repeated for all the player's involved in the event)
+
+      - name: last_play_period
+        description: The period in which the previous play's event occured (e.g. 3)
 
       - name: penalty_severity
         description: If the play in question was a penalty, this column will describe its severity (e.g. MINOR, MAJOR), else null

--- a/models/staging/stg_nhl__live_plays.yml
+++ b/models/staging/stg_nhl__live_plays.yml
@@ -185,3 +185,30 @@ models:
 
       - name: game_state_lag
         description: The previous state of scoreboard prior to the play in question (e.g. "Tie", "Close" (1 goal difference), "Buffer" (2 goal difference), "Comfortable" (3 goal difference), "Blowout" (4 goal difference))
+
+      - name: last_shot_event_idx
+        description: Looks back to the last (previous) shot, returns the event sequence (e.g. 1 = first event, 2 = second event)
+
+      - name: last_shot_team_id
+        description: Looks back to the last (previous) shot, returns the team_id for the shoot
+
+      - name: last_shot_period
+        description: Looks back to the last (previous) shot, returns the period
+
+      - name: last_shot_total_seconds_elapsed
+        description: Looks back to the last (previous) shot, returns the total seconds elapsed
+
+      - name: last_shot_event_type
+        description: Looks back to the last (previous) shot, returns the event type (e.g. 'GOAL', 'MISSED_SHOT', 'SHOT', 'GOAL')
+
+      - name: last_shot_event_secondary_type
+        description: Looks back to the last (previous) shot, returns the event_secondary_type (e.g. basically, shot type)
+
+      - name: last_shot_x_coordinate
+        description: Looks back to the last (previous) shot, returns the x_coordinate
+
+      - name: last_shot_y_coordinate
+        description: Looks back to the last (previous) shot, returns the y_coordinate
+
+      - name: last_shot_saved_shot_ind
+        description: Looks back to the last (previous) shot, returns a '1' if the shot was taken by same team, in the same period, and was on target but did not result in a goal


### PR DESCRIPTION
# Overview
- Rebounds, defined as a corsi-shot (any shot) within 2 seconds of a saved-shot from the same team in the same period excluding shootouts, are usually highly predictive of a goal
- This work included classifying shots as rebounds or not, by leveraging lag features in the play-by-play dataset
- Resolves [#62](https://github.com/bicks-bapa-roob/dbt-nhl-breakouts/issues/62)

# Changes
1. `stg_nhl__live_plays`
  - added `last_shot` cte: each row in this dataset was a shot taken by the shooter/goalscorer within regulation/OT... added `lag` features denoted by the prefix `last_shot_` with the intention of using them to create shot-features later on, including rebound classification 
  - refactored code for readability
  - updated the dependent `yml` file
2.  `f_plays`
  - added `last_shot_` features, in addition to creating `last_shots_seconds` & `last_shot_rebound_ind`
  - updated the dependent `yml` file
3.  `f_player_season`
  - added`last_shot_rebound_ind` an summarized it to created 4 new rebound features: `shots_rebound_all`,  `shots_rebound_saved`, `shots_rebound_goal`, `pcnt_shooting_rebound`
  - updated the dependent `yml` file
# Other notes
- Nah.
# Checks
- [ ] All models ran successfully
- [ ] Changes to models are reflected in the schema.yml
Pick one:
- [ ] No test failures OR
- [ ] No new test failures, and there is a plan in place to address existing ones
