### PR TITLE
Enhancing x & y coordinates with context and metrics

### DIFF
--- a/analyses/archive/rink_dimensions.sql
+++ b/analyses/archive/rink_dimensions.sql
@@ -1,0 +1,148 @@
+-- CTE to pull all home team shots in the first period from non-goalie skaters
+WITH home_shot_data AS (
+  SELECT
+    p.play_id
+    , DATE(p.play_time) AS game_date
+    , p.game_id
+    , p.event_id
+    , p.event_type
+    , p.team_id
+    , t.full_name AS team_full_name
+    , p.player_role_team
+    , p.player_id
+    , p.player_full_name
+    , p.event_code
+    , p.event_description
+    , p.play_x_coordinate
+    , p.play_y_coordinate
+    , p.play_period
+    , p.play_period_time_elapsed
+
+  FROM
+    `nhl-breakouts.analytics_intermediate.f_plays` p
+    INNER JOIN `nhl-breakouts.analytics_intermediate.d_teams` t ON p.team_id = t.team_id
+    INNER JOIN `nhl-breakouts.analytics_intermediate.d_players`pl ON p.player_id = pl.player_id
+
+  WHERE 1=1
+    AND p.event_type IN ('GOAL', 'MISSED_SHOT', 'SHOT')
+    AND p.play_period = 1
+    AND p.player_role_team = 'HOME'
+    AND pl.primary_position_name <> 'Goalie'
+
+  ORDER BY
+    DATE(p.play_time) DESC
+)
+
+-- Determine which end the home team is shooting at during the first period for each team
+, first_period_shot_location AS (
+  SELECT
+    sd.team_id
+    , sd.team_full_name
+    , SUM(CASE WHEN CAST(sd.play_x_coordinate AS FLOAT64) > 0 THEN 1 ELSE 0 END) AS right_end
+    , SUM(CASE WHEN CAST(sd.play_x_coordinate AS FLOAT64) < 0 THEN 1 ELSE 0 END) AS left_end
+
+  FROM
+    home_shot_data sd
+
+  WHERE 1=1
+
+  GROUP BY
+    sd.team_id
+    , sd.team_full_name
+)
+
+-- Depending on which end a majority of shots are towards, assign each team a home_first_period_shooting_end
+, shooting_end AS (
+  SELECT
+    DISTINCT sd.team_id
+    , CASE WHEN fp.right_end > fp.left_end THEN 'right_end' ELSE 'left_end' END AS home_first_period_shooting_end
+
+  FROM
+    home_shot_data sd
+    INNER JOIN first_period_shot_location fp ON sd.team_id = fp.team_id
+)
+
+-- Depending on which end the team is shooting on, adjust the x and y play coordinates so that all shots are taken towards the same end (all shots towards right end)
+, adjusted_coordinates AS (
+  SELECT
+    p.play_id
+    , DATE(p.play_time) AS game_date
+    , p.game_id
+    , p.event_id
+    , p.event_type
+    , p.team_id
+    , t.full_name AS team_full_name
+    , p.player_role_team
+    , p.player_id
+    , p.player_full_name
+    , p.event_code
+    , p.event_description
+    , p.play_x_coordinate
+    , p.play_y_coordinate
+    , CASE
+        WHEN p.player_role_team = 'HOME' AND se.home_first_period_shooting_end = 'left_end' AND MOD(p.play_period, 2) > 0 THEN CAST(p.play_x_coordinate AS FLOAT64)*-1
+        WHEN p.player_role_team = 'HOME' AND se.home_first_period_shooting_end = 'left_end' AND MOD(p.play_period, 2) = 0 THEN CAST(p.play_x_coordinate AS FLOAT64)
+        WHEN p.player_role_team = 'HOME' AND se.home_first_period_shooting_end = 'right_end' AND MOD(p.play_period, 2) > 0 THEN CAST(p.play_x_coordinate AS FLOAT64)
+        WHEN p.player_role_team = 'HOME' AND se.home_first_period_shooting_end = 'right_end' AND MOD(p.play_period, 2) = 0 THEN CAST(p.play_x_coordinate AS FLOAT64)*-1
+        WHEN p.player_role_team = 'AWAY' AND se.home_first_period_shooting_end = 'left_end' AND MOD(p.play_period, 2) > 0 THEN CAST(p.play_x_coordinate AS FLOAT64)
+        WHEN p.player_role_team = 'AWAY' AND se.home_first_period_shooting_end = 'left_end' AND MOD(p.play_period, 2) = 0 THEN CAST(p.play_x_coordinate AS FLOAT64)*-1
+        WHEN p.player_role_team = 'AWAY' AND se.home_first_period_shooting_end = 'right_end' AND MOD(p.play_period, 2) > 0 THEN CAST(p.play_x_coordinate AS FLOAT64)*-1
+        WHEN p.player_role_team = 'AWAY' AND se.home_first_period_shooting_end = 'right_end' AND MOD(p.play_period, 2) = 0 THEN CAST(p.play_x_coordinate AS FLOAT64)
+      END AS adj_play_x_coordinate
+    , CASE
+        WHEN p.player_role_team = 'HOME' AND se.home_first_period_shooting_end = 'left_end' AND MOD(p.play_period, 2) > 0 THEN CAST(p.play_y_coordinate AS FLOAT64)*-1
+        WHEN p.player_role_team = 'HOME' AND se.home_first_period_shooting_end = 'left_end' AND MOD(p.play_period, 2) = 0 THEN CAST(p.play_y_coordinate AS FLOAT64)
+        WHEN p.player_role_team = 'HOME' AND se.home_first_period_shooting_end = 'right_end' AND MOD(p.play_period, 2) > 0 THEN CAST(p.play_y_coordinate AS FLOAT64)
+        WHEN p.player_role_team = 'HOME' AND se.home_first_period_shooting_end = 'right_end' AND MOD(p.play_period, 2) = 0 THEN CAST(p.play_y_coordinate AS FLOAT64)*-1
+        WHEN p.player_role_team = 'AWAY' AND se.home_first_period_shooting_end = 'left_end' AND MOD(p.play_period, 2) > 0 THEN CAST(p.play_y_coordinate AS FLOAT64)
+        WHEN p.player_role_team = 'AWAY' AND se.home_first_period_shooting_end = 'left_end' AND MOD(p.play_period, 2) = 0 THEN CAST(p.play_y_coordinate AS FLOAT64)*-1
+        WHEN p.player_role_team = 'AWAY' AND se.home_first_period_shooting_end = 'right_end' AND MOD(p.play_period, 2) > 0 THEN CAST(p.play_y_coordinate AS FLOAT64)*-1
+        WHEN p.player_role_team = 'AWAY' AND se.home_first_period_shooting_end = 'right_end' AND MOD(p.play_period, 2) = 0 THEN CAST(p.play_y_coordinate AS FLOAT64)
+      END AS adj_play_y_coordinate
+    , p.play_period
+    , p.play_period_time_elapsed
+    , g.home_team_id
+    , g.away_team_id
+    , se.home_first_period_shooting_end
+
+  FROM
+    `nhl-breakouts.analytics_intermediate.f_plays` p
+    INNER JOIN `nhl-breakouts.analytics_intermediate.d_teams` t ON p.team_id = t.team_id
+    INNER JOIN `nhl-breakouts.analytics_intermediate.d_players` pl ON p.player_id = pl.player_id
+    INNER JOIN `nhl-breakouts.analytics_intermediate.f_games` g ON p.game_id = g.game_id
+    INNER JOIN shooting_end se ON g.home_team_id = se.team_id
+
+  WHERE 1=1
+    AND p.event_type IN ('GOAL', 'MISSED_SHOT', 'SHOT')
+)
+
+-- Assign each shot a zone based on the adjusted coordinates
+, rink_dimensions AS (
+  SELECT
+    ac.*
+    , CASE
+      WHEN adj_play_x_coordinate BETWEEN -25 AND 25 THEN 'NEUTRAL_ZONE'
+      WHEN adj_play_x_coordinate BETWEEN -100 AND -25 THEN 'DEFENSIVE_ZONE'
+      WHEN (adj_play_x_coordinate BETWEEN 25 AND 54) AND (adj_play_y_coordinate BETWEEN -42.5 AND -7) THEN 'R_POINT'
+      WHEN (adj_play_x_coordinate BETWEEN 25 AND 54) AND (adj_play_y_coordinate BETWEEN -7 AND 7) THEN 'C_POINT'
+      WHEN (adj_play_x_coordinate BETWEEN 25 AND 54) AND (adj_play_y_coordinate BETWEEN 7 AND 42.5) THEN 'L_POINT'
+      WHEN (adj_play_x_coordinate BETWEEN 54 AND 69) AND (adj_play_y_coordinate BETWEEN -42.5 AND -22) THEN 'R_1_HIGH'
+      WHEN (adj_play_x_coordinate BETWEEN 54 AND 69) AND (adj_play_y_coordinate BETWEEN -22 AND -7) THEN 'R_2_HIGH'
+      WHEN (adj_play_x_coordinate BETWEEN 52 AND 69) AND (adj_play_y_coordinate BETWEEN -7 AND 7) THEN 'HIGH_SLOT'
+      WHEN (adj_play_x_coordinate BETWEEN 52 AND 69) AND (adj_play_y_coordinate BETWEEN 7 AND 22) THEN 'L_2_HIGH'
+      WHEN (adj_play_x_coordinate BETWEEN 52 AND 69) AND (adj_play_y_coordinate BETWEEN 22 AND 42.5) THEN 'L_1_HIGH'
+      WHEN (adj_play_x_coordinate BETWEEN 69 AND 89) AND (adj_play_y_coordinate BETWEEN -42.5 AND -22) THEN 'R_1_LOW'
+      WHEN (adj_play_x_coordinate BETWEEN 69 AND 89) AND (adj_play_y_coordinate BETWEEN -22 AND -7) THEN 'R_2_LOW'
+      WHEN (adj_play_x_coordinate BETWEEN 69 AND 89) AND (adj_play_y_coordinate BETWEEN -7 AND 7) THEN 'LOW_SLOT'
+      WHEN (adj_play_x_coordinate BETWEEN 69 AND 89) AND (adj_play_y_coordinate BETWEEN 7 AND 22) THEN 'L_2_LOW'
+      WHEN (adj_play_x_coordinate BETWEEN 69 AND 89) AND (adj_play_y_coordinate BETWEEN 22 AND 42.5) THEN 'L_1_LOW'
+      WHEN (adj_play_x_coordinate BETWEEN 89 AND 100) THEN 'DOWN_LOW'
+    END AS zone
+  FROM
+    adjusted_coordinates ac
+)
+
+-- QC results
+SELECT *
+FROM rink_dimensions
+LIMIT 5;

--- a/analyses/archive/rink_location.sql
+++ b/analyses/archive/rink_location.sql
@@ -1,0 +1,68 @@
+-- #cte: depending on which end the team is shooting on, adjust the x and y play coordinates so that all plays are going towards the same end (all shots towards right end)
+with adj_coordinates as (
+  select
+    plays.play_id
+    , plays.event_type
+    , plays.play_x_coordinate
+    , plays.play_y_coordinate
+    , lower(plays.player_role_team) as player_role_team
+    , plays.play_period
+    , schedule.home_period1_shooting
+    -- Flip the x-y coords based on where the player's team was shooting in the first period of the game (reminder that when mod(x, 2) = 0 then odd number, but when > 0 then  even number)
+      , case
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)*-1
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)*-1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)*-1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)*-1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)
+        end as adj_play_x_coordinate
+      , case
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)*-1
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)*-1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)*-1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)*-1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)
+        end as adj_play_y_coordinate
+  from `nhl-breakouts.dbt_dom.f_plays` as plays
+  left join `nhl-breakouts.dbt_dom.d_schedule` as schedule on schedule.game_id = plays.game_id
+)
+
+select
+  ac.*
+-- Rink distance from goal (shooting)
+  , sqrt(power((89 - abs(adj_play_x_coordinate)),2) + power(adj_play_y_coordinate,2)) as goal_distance
+-- Rink angle from goal (shooting)
+  , atan( (adj_play_y_coordinate / (89 - adj_play_x_coordinate)) ) * (180 / (acos(-1))) as angle
+-- Rink zones
+  , case
+    when adj_play_x_coordinate between -25 and 25 then 'neutral_zone'
+    when adj_play_x_coordinate between -100 and -25 then 'defensive_zone'
+    else 'offensive_zone'
+    end as zone_type
+  , case
+    when adj_play_x_coordinate between -25 and 25 then 'neutral_zone'
+    when adj_play_x_coordinate between -100 and -25 then 'defensive_zone'
+    when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between -42.5 and -7) then 'r_point'
+    when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between -7 and 7) then 'c_point'
+    when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between 7 and 42.5) then 'l_point'
+    when (adj_play_x_coordinate between 54 and 69) and (adj_play_y_coordinate between -42.5 and -22) then 'r_1_high'
+    when (adj_play_x_coordinate between 54 and 69) and (adj_play_y_coordinate between -22 and -7) then 'r_2_high'
+    when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between -7 and 7) then 'high_slot'
+    when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between 7 and 22) then 'l_2_high'
+    when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between 22 and 42.5) then 'l_1_high'
+    when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -42.5 and -22) then 'r_1_low'
+    when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -22 and -7) then 'r_2_low'
+    when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -7 and 7) then 'low_slot'
+    when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between 7 and 22) then 'l_2_low'
+    when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between 22 and 42.5) then 'l_1_low'
+    when (adj_play_x_coordinate between 89 and 100) then 'down_low'
+    end as zone
+from adj_coordinates as ac
+limit 1000
+

--- a/models/analytics/core/f_player_season.sql
+++ b/models/analytics/core/f_player_season.sql
@@ -85,8 +85,8 @@ boxscore_stats as (
         , lower(away_result_of_play) as away_result_of_play
         , home_skaters
         , away_skaters
-        , last_shot_seconds
-        , last_shot_rebound_ind
+        , seconds_since_last_shot
+        , shot_rebound_ind
     from {{ ref('f_plays') }} as plays
     left join {{ ref('d_schedule') }} as schedule on schedule.game_id = plays.game_id
     left join {{ ref('d_seasons') }} as season on season.season_id = schedule.season_id
@@ -143,7 +143,7 @@ boxscore_stats as (
         , skater_type
         , event_type
         , event_secondary_type
-        , last_shot_rebound_ind as shots_rebound
+        , shot_rebound_ind as shots_rebound
         -- shot calculations
         , case when s.event_type in ('goal', 'shot') then 1 else 0 end as shots_ongoal
         , case when s.event_type = 'blocked_shot' then 1 else 0 end as shots_blocked

--- a/models/analytics/core/f_player_season.yml
+++ b/models/analytics/core/f_player_season.yml
@@ -161,6 +161,9 @@ models:
       - name: shots_wristshot_all
         description: The number of wristshot shots that were either saved or were goals (no misses or blocks)
 
+      - name: shots_rebound_all
+        description: The number of rebounds (shot taken within 2 seconds of previous if taken by same team and same period) that were either saved or were goals (no misses or blocks)
+
       ## Skater shot results by type (shot-saved)
       - name: shots_backhand_saved
         description: The number of backhand shots that were saved
@@ -183,6 +186,9 @@ models:
       - name: shots_wristshot_saved
         description: The number of wristshot shots that were saved
 
+      - name: shots_rebound_saved
+        description: The number of rebounds (shot taken within 2 seconds of previous if taken by same team and same period) that were saved
+
       ## Skater shot results by type (shot-goal)
       - name: shots_backhand_goal
         description: The number of backhand shots that were goals
@@ -204,6 +210,10 @@ models:
 
       - name: shots_wristshot_goal
         description: The number of wristshot shots that were goals
+
+      - name: shots_rebound_goal
+        description: The number of rebounds (shot taken within 2 seconds of previous if taken by same team and same period) that were goals
+
 
       - name: pcnt_ff
         description: Fenwick for percentage (while on the ice) = Fenwick shots for / (Fenwick shots for + Fenwick shots against)
@@ -244,6 +254,9 @@ models:
 
       - name: pcnt_shooting_wristshot
         description: The percent of all wristshot shots on goal that were goals (e.g. 10% shooting means 1 out of 10 wristshot shots on net were goals)
+
+      - name: pcnt_shooting_rebound
+        description: The percent of all rebound shots on goal that were goals (e.g. 10% shooting means 1 out of 10 rebound shots on net were goals)
 
       ## Other skater stats
       - name: faceoff_wins

--- a/models/analytics/intermediate/d_schedule.sql
+++ b/models/analytics/intermediate/d_schedule.sql
@@ -1,6 +1,6 @@
 select
     /* Primary Key */
-    stg_nhl__schedule_id as schedule_id
+    schedule.stg_nhl__schedule_id as schedule_id
 
     /* Identifiers */
     , schedule.game_id

--- a/models/analytics/intermediate/d_schedule.sql
+++ b/models/analytics/intermediate/d_schedule.sql
@@ -3,41 +3,69 @@ select
     stg_nhl__schedule_id as schedule_id
 
     /* Identifiers */
-    , game_id
-    , season_id
-    , away_team_id
-    , home_team_id
-    , venue_id
+    , schedule.game_id
+    , schedule.season_id
+    , schedule.away_team_id
+    , schedule.home_team_id
+    , schedule.venue_id
 
-    /* Properties */
-    , game_number
-    , game_type
-    , game_type_description
-    , game_date
-    , abstract_game_state
-    , coded_game_state
-    , detailed_state
-    , status_code
-    , is_start_time_tbd
-    , away_team_wins
-    , away_team_losses
-    , away_team_ot
-    , away_team_type
-    , away_team_score
-    , away_team_name
-    , away_team_url
-    , home_team_wins
-    , home_team_losses
-    , home_team_ot
-    , home_team_type
-    , home_team_score
-    , home_team_name
-    , home_team_url
-    , venue_name
-    , venue_url
-    , content_url
-    , url
-    , extracted_at
-    , loaded_at
+    /* Schedule Properties */
+    , schedule.game_number
+    , schedule.game_type
+    , schedule.game_type_description
+    , schedule.game_date
+    , schedule.abstract_game_state
+    , schedule.coded_game_state
+    , schedule.detailed_state
+    , schedule.status_code
+    , schedule.is_start_time_tbd
+    , schedule.away_team_wins
+    , schedule.away_team_losses
+    , schedule.away_team_ot
+    , schedule.away_team_type
+    , schedule.away_team_score
+    , schedule.away_team_name
+    , schedule.home_team_wins
+    , schedule.home_team_losses
+    , schedule.home_team_ot
+    , schedule.home_team_type
+    , schedule.home_team_score
+    , schedule.home_team_name
+    , schedule.venue_name
+
+    /* Rink Shooting Properties */
+    -- ...this dataset brings in p1_shooting_location, which is the location where shots were going in period 1 for the home team
+
+    -- ... now, classify for the home team with the assumption that each period switches sides
+    , rs.p1_shooting_location as home_period1_shooting
+    , case
+        when rs.p1_shooting_location = 'right' then 'left'
+        when rs.p1_shooting_location = 'left' then 'right'
+        else rs.p1_shooting_location
+    end as home_period2_shooting
+    , rs.p1_shooting_location as home_period3_shooting
+    -- ... now, classify for the away team with the assumption that each period switches sides
+    , case
+        when rs.p1_shooting_location = 'right' then 'left'
+        when rs.p1_shooting_location = 'left' then 'right'
+        else rs.p1_shooting_location
+    end as away_period1_shooting
+    , rs.p1_shooting_location as away_period2_shooting
+    , case
+        when rs.p1_shooting_location = 'right' then 'left'
+        when rs.p1_shooting_location = 'left' then 'right'
+        else rs.p1_shooting_location
+    end as away_period3_shooting
+
+    /* Additioanl properties */
+    , schedule.home_team_url
+    , schedule.away_team_url
+    , schedule.venue_url
+    , schedule.content_url
+    , schedule.url
+    , schedule.extracted_at
+    , schedule.loaded_at
 from
-    {{ ref('stg_nhl__schedule') }}
+    {{ ref('stg_nhl__schedule') }} as schedule
+left join {{ ref('stg_nhl__rink_shooting') }} as rs on rs.game_id = schedule.game_id
+

--- a/models/analytics/intermediate/d_schedule.yml
+++ b/models/analytics/intermediate/d_schedule.yml
@@ -84,9 +84,6 @@ models:
       - name: away_team_name
         description: Away team name
 
-      - name: away_team_url
-        description: Away team URL endpoint
-
       - name: home_team_wins
         description: Cumulative number of wins for the home team for the given season (wins for the team at that point in time)
 
@@ -105,11 +102,32 @@ models:
       - name: home_team_name
         description: Home team name
 
-      - name: home_team_url
-        description: Home team URL endpoint
+      - name: home_period1_shooting
+        description: The direction that the home team is shooting towards in period 1 ('left', 'right', 'missing')
+
+      - name: home_period2_shooting
+        description: The direction that the home team is shooting towards in period 2 ('left', 'right', 'missing')
+
+      - name: home_period3_shooting
+        description: The direction that the home team is shooting towards in period 3 ('left', 'right', 'missing')
+
+      - name: away_period1_shooting
+        description: The direction that the away team is shooting towards in period 1 ('left', 'right', 'missing')
+
+      - name: away_period2_shooting
+        description: The direction that the away team is shooting towards in period 2 ('left', 'right', 'missing')
+
+      - name: away_period3_shooting
+        description: The direction that the away team is shooting towards in period 3 ('left', 'right', 'missing')
 
       - name: venue_name
         description: Home team's venue / arena that the teams played in
+
+      - name: home_team_url
+        description: Home team URL endpoint
+
+      - name: away_team_url
+        description: Away team URL endpoint
 
       - name: venue_url
         description: URL endpoint for the venue

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -19,6 +19,7 @@ select
     , plays.event_type
     , plays.event_secondary_type
     , plays.event_description
+    , plays.last_player_role_team
     , plays.last_play_event_type
     , plays.last_play_event_secondary_type
     , plays.last_play_event_description

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -61,6 +61,28 @@ select
     , plays.goal_difference_lag
     , plays.winning_team_lag
     , plays.game_state_lag
+    , plays.last_shot_event_idx
+    , plays.last_shot_team_id
+    , plays.last_shot_period
+    , plays.last_shot_total_seconds_elapsed
+    , plays.last_shot_event_type
+    , plays.last_shot_event_secondary_type
+    , plays.last_shot_x_coordinate
+    , plays.last_shot_y_coordinate
+    , plays.last_shot_saved_shot_ind
+    -- seconds since last shot: if the last shot was take by the same team in the same period, get the time elapsed between shots
+    , case
+        when plays.last_shot_saved_shot_ind = 1
+            then play_total_seconds_elapsed - last_shot_total_seconds_elapsed
+        else 0
+    end as last_shot_seconds
+    -- rebounds: if the last shot was take by the same team in the same period, and the time elapsed between shots was between 0 - 2 seconds, then 1 else 0
+    , case
+        when plays.last_shot_saved_shot_ind = 1
+            and (play_total_seconds_elapsed - last_shot_total_seconds_elapsed) <= 2
+            then 1
+        else 0
+    end as last_shot_rebound_ind
 
     /* Shift properties */
     , shifts.shift_id

--- a/models/analytics/intermediate/f_plays.sql
+++ b/models/analytics/intermediate/f_plays.sql
@@ -73,13 +73,13 @@ select
     -- seconds since last shot: if the last shot was take by the same team in the same period, get the time elapsed between shots
     , case
         when plays.last_shot_saved_shot_ind = 1
-            then play_total_seconds_elapsed - last_shot_total_seconds_elapsed
+            then (plays.play_total_seconds_elapsed - plays.last_shot_total_seconds_elapsed)
         else 0
     end as last_shot_seconds
     -- rebounds: if the last shot was take by the same team in the same period, and the time elapsed between shots was between 0 - 2 seconds, then 1 else 0
     , case
         when plays.last_shot_saved_shot_ind = 1
-            and (play_total_seconds_elapsed - last_shot_total_seconds_elapsed) <= 2
+            and (plays.play_total_seconds_elapsed - plays.last_shot_total_seconds_elapsed) <= 2
             then 1
         else 0
     end as last_shot_rebound_ind

--- a/models/analytics/intermediate/f_plays.yml
+++ b/models/analytics/intermediate/f_plays.yml
@@ -280,5 +280,36 @@ models:
       - name: away_goalie_on_ice
         description: The number of away goalies on the ice (1 or 0)
 
+      - name: last_shot_event_idx
+        description: Looks back to the last (previous) shot, returns the event sequence (e.g. 1 = first event, 2 = second event)
 
+      - name: last_shot_team_id
+        description: Looks back to the last (previous) shot, returns the team_id for the shoot
+
+      - name: last_shot_period
+        description: Looks back to the last (previous) shot, returns the period
+
+      - name: last_shot_total_seconds_elapsed
+        description: Looks back to the last (previous) shot, returns the total seconds elapsed
+
+      - name: last_shot_event_type
+        description: Looks back to the last (previous) shot, returns the event type (e.g. 'GOAL', 'MISSED_SHOT', 'SHOT', 'GOAL')
+
+      - name: last_shot_event_secondary_type
+        description: Looks back to the last (previous) shot, returns the event_secondary_type (e.g. basically, shot type)
+
+      - name: last_shot_x_coordinate
+        description: Looks back to the last (previous) shot, returns the x_coordinate
+
+      - name: last_shot_y_coordinate
+        description: Looks back to the last (previous) shot, returns the y_coordinate
+
+      - name: last_shot_saved_shot_ind
+        description: Looks back to the last (previous) shot, returns a '1' if the shot was taken by same team, in the same period, and was on target but did not result in a goal
+
+      - name: last_shot_seconds
+        description: Seconds since last shot - returns the time elapsed between shots if the shot was taken by same team, in the same period, and was on target but did not result in a goal
+
+      - name: last_shot_rebound_ind
+        description: Rebounds indicator - returns a '1' if the shot was taken by same team, in the same period, was on target but did not result in a goal, and the time elapsed between shots was between 0 - 2 seconds
 

--- a/models/analytics/intermediate/f_plays.yml
+++ b/models/analytics/intermediate/f_plays.yml
@@ -55,17 +55,29 @@ models:
       - name: player_role_team
         description: The home / away status of the player's team
 
+      - name: event_code
+        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+
       - name: event_type
         description: Short description of the event type
 
-      - name: event_code
-        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+      - name: event_secondary_type
+        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
 
       - name: event_description
         description: Long description of the event (repeated for all the player's involved in the event)
 
-      - name: event_secondary_type
-        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+      - name: last_play_event_type
+        description: Short description of the previous play's event type
+
+      - name: last_play_event_secondary_type
+        description: If the previous play's event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+
+      - name: last_play_event_description
+        description: Long description of the previous play's event (repeated for all the player's involved in the event)
+
+      - name: last_play_period
+        description: The period in which the previous play's event occured (e.g. 3)
 
       - name: penalty_severity
         description: If the play in question was a penalty, this column will describe its severity (e.g. MINOR, MAJOR), else null
@@ -73,10 +85,10 @@ models:
       - name: penalty_minutes
         description: If the play in question was a penalty, this column will return the number of minutes the penalty was assessed for, else null
 
-      - name: play_x_coordinate
+      - name: x_coordinate
         description: The x-coordinate of where the event took place on the ice
 
-      - name: play_y_coordinate
+      - name: y_coordinate
         description: The y-coordinate of where the event took place on the ice
 
       - name: play_period
@@ -139,6 +151,12 @@ models:
       - name: blockedshots_home
         description: Cumulative home team blocked shots made in the game at the point in time where the event occured
 
+      - name: seconds_since_last_shot
+        description: Seconds since last shot - returns the time elapsed between shots if the shot was taken by same team, in the same period, and was on target but did not result in a goal
+
+      - name: shot_rebound_ind
+        description: Rebounds indicator - returns a '1' if the shot was taken by same team, in the same period, was on target but did not result in a goal, and the time elapsed between shots was between 0 - 2 seconds
+
       - name: penalties_away
         description: Cumulative away team penalties in minutes taken in the game at the point in time where the event occured
 
@@ -193,6 +211,79 @@ models:
       - name: game_state_lag
         description: The previous state of scoreboard prior to the play in question (e.g. "Tie", "Close" (1 goal difference), "Buffer" (2 goal difference), "Comfortable" (3 goal difference), "Blowout" (4 goal difference))
 
+      # Location properties
+      - name: adj_x_coordinate
+        description: Adjusting the axis of plane of the play's x-coordinate based on where the oppsosing team's goalie net is as this is where they will be shooting towards
+
+      - name: adj_y_coordinate
+        description: Adjusting the axis of plane of the play's y-coordinate based on where the oppsosing team's goalie net is as this is where they will be shooting towards
+
+      - name: play_distance
+        description: Distance from the opposing goal, calculated by making a right angle with the play's [x,y] and the net [89,0], and finding the hypotenuse with the formula c = sqrt(a^2 + b^2)
+
+      - name: play_angle
+        description: Angle from the play's [x,y] coordinates to the opposing team's net [89,0]
+
+      - name: rink_side
+        description: The side of the rink based on the y-coordinate (e.g. "left" means that the team is on the left side of the rink)
+
+      - name: zone_type
+        description: Classifying each of the zones by its type, based on the x-coordinate (e.g. "offensive_zone")
+
+      - name: zone
+        description: The the area of the ice, determined by combining the x & y coordinates (e.g. "r_1_high")
+
+      # Last shot location properties
+      - name: last_shot_event_idx
+        description: Looks back to the last (previous) shot, returns the event sequence (e.g. 1 = first event, 2 = second event)
+
+      - name: last_shot_team_id
+        description: Looks back to the last (previous) shot, returns the team_id for the shoot
+
+      - name: last_shot_period
+        description: Looks back to the last (previous) shot, returns the period
+
+      - name: last_shot_total_seconds_elapsed
+        description: Looks back to the last (previous) shot, returns the total seconds elapsed
+
+      - name: last_shot_event_type
+        description: Looks back to the last (previous) shot, returns the event type (e.g. 'GOAL', 'MISSED_SHOT', 'SHOT', 'GOAL')
+
+      - name: last_shot_event_secondary_type
+        description: Looks back to the last (previous) shot, returns the event_secondary_type (e.g. basically, shot type)
+
+      - name: last_shot_x_coordinate
+        description: Looks back to the last (previous) shot, returns the x_coordinate
+
+      - name: last_shot_y_coordinate
+        description: Looks back to the last (previous) shot, returns the y_coordinate
+
+      - name: last_shot_saved_shot_ind
+        description: Looks back to the last (previous) shot, returns a '1' if the shot was taken by same team, in the same period, and was on target but did not result in a goal
+
+      # Last play location properties
+      - name: last_play_adj_x_coordinate
+        description: Adjusting the axis of plane of the play's x-coordinate based on where the oppsosing team's goalie net is as this is where they will be shooting towards
+
+      - name: last_play_y_coordinate
+        description: Adjusting the axis of plane of the play's y-coordinate based on where the oppsosing team's goalie net is as this is where they will be shooting towards
+
+      - name: last_play_distance
+        description: Distance from the opposing goal, calculated by making a right angle with the play's [x,y] and the net [89,0], and finding the hypotenuse with the formula c = sqrt(a^2 + b^2)
+
+      - name: last_play_angle
+        description: Angle from the play's [x,y] coordinates to the opposing team's net [89,0]
+
+      - name: last_play_rink_side
+        description: The side of the rink based on the y-coordinate (e.g. "left" means that the team is on the left side of the rink)
+
+      - name: last_play_zone_type
+        description: Classifying each of the zones by its type, based on the x-coordinate (e.g. "offensive_zone")
+
+      - name: last_play_zone
+        description: The the area of the ice, determined by combining the x & y coordinates (e.g. "r_1_high")
+
+      # Shift properties
       - name: shift_id
         description: Custom identifier for an NHL shift-second
 
@@ -279,37 +370,4 @@ models:
 
       - name: away_goalie_on_ice
         description: The number of away goalies on the ice (1 or 0)
-
-      - name: last_shot_event_idx
-        description: Looks back to the last (previous) shot, returns the event sequence (e.g. 1 = first event, 2 = second event)
-
-      - name: last_shot_team_id
-        description: Looks back to the last (previous) shot, returns the team_id for the shoot
-
-      - name: last_shot_period
-        description: Looks back to the last (previous) shot, returns the period
-
-      - name: last_shot_total_seconds_elapsed
-        description: Looks back to the last (previous) shot, returns the total seconds elapsed
-
-      - name: last_shot_event_type
-        description: Looks back to the last (previous) shot, returns the event type (e.g. 'GOAL', 'MISSED_SHOT', 'SHOT', 'GOAL')
-
-      - name: last_shot_event_secondary_type
-        description: Looks back to the last (previous) shot, returns the event_secondary_type (e.g. basically, shot type)
-
-      - name: last_shot_x_coordinate
-        description: Looks back to the last (previous) shot, returns the x_coordinate
-
-      - name: last_shot_y_coordinate
-        description: Looks back to the last (previous) shot, returns the y_coordinate
-
-      - name: last_shot_saved_shot_ind
-        description: Looks back to the last (previous) shot, returns a '1' if the shot was taken by same team, in the same period, and was on target but did not result in a goal
-
-      - name: last_shot_seconds
-        description: Seconds since last shot - returns the time elapsed between shots if the shot was taken by same team, in the same period, and was on target but did not result in a goal
-
-      - name: last_shot_rebound_ind
-        description: Rebounds indicator - returns a '1' if the shot was taken by same team, in the same period, was on target but did not result in a goal, and the time elapsed between shots was between 0 - 2 seconds
 

--- a/models/analytics/intermediate/f_plays.yml
+++ b/models/analytics/intermediate/f_plays.yml
@@ -67,6 +67,9 @@ models:
       - name: event_description
         description: Long description of the event (repeated for all the player's involved in the event)
 
+      - name: last_player_role_team
+        description: The home / away status of the player's team from the previous (most recent) play
+
       - name: last_play_event_type
         description: Short description of the previous play's event type
 

--- a/models/staging/stg_nhl__boxscore_player.sql
+++ b/models/staging/stg_nhl__boxscore_player.sql
@@ -1,8 +1,7 @@
 with
 -- CTE1
 live_boxscore as (
-    select
-        *
+    select *
     from
         {{ source('meltano', 'live_boxscore') }}
 )

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -201,6 +201,7 @@ live_plays as (
         , bp.event_code
         , bp.event_description
         , bp.event_secondary_type
+        , lag(bp.player_role_team) over (partition by game_id order by event_idx) as last_player_role_team
         , lag(bp.event_type) over (partition by game_id order by event_idx) as last_play_event_type
         , lag(bp.event_secondary_type) over (partition by game_id order by event_idx) as last_play_event_secondary_type
         , lag(bp.event_description) over (partition by game_id order by event_idx) as last_play_event_description
@@ -469,6 +470,7 @@ select
     , gs.event_type
     , gs.event_secondary_type
     , gs.event_description
+    , gs.last_player_role_team
     , gs.last_play_event_type
     , gs.last_play_event_secondary_type
     , gs.last_play_event_description

--- a/models/staging/stg_nhl__live_plays.sql
+++ b/models/staging/stg_nhl__live_plays.sql
@@ -201,6 +201,10 @@ live_plays as (
         , bp.event_code
         , bp.event_description
         , bp.event_secondary_type
+        , lag(bp.event_type) over (partition by game_id order by event_idx) as last_play_event_type
+        , lag(bp.event_secondary_type) over (partition by game_id order by event_idx) as last_play_event_secondary_type
+        , lag(bp.event_description) over (partition by game_id order by event_idx) as last_play_event_description
+        , ifnull(lag(bp.play_period) over (partition by game_id order by event_idx), play_period) as last_play_period
         , bp.penalty_severity
         , bp.penalty_minutes
         , bp.play_x_coordinate
@@ -461,10 +465,14 @@ select
     , gs.player_secondary_assist
     , gs.player_role
     , gs.player_role_team
-    , gs.event_type
     , gs.event_code
-    , gs.event_description
+    , gs.event_type
     , gs.event_secondary_type
+    , gs.event_description
+    , gs.last_play_event_type
+    , gs.last_play_event_secondary_type
+    , gs.last_play_event_description
+    , gs.last_play_period
     , gs.penalty_severity
     , gs.penalty_minutes
     , gs.play_x_coordinate

--- a/models/staging/stg_nhl__live_plays.yml
+++ b/models/staging/stg_nhl__live_plays.yml
@@ -60,6 +60,9 @@ models:
       - name: event_description
         description: Long description of the event (repeated for all the player's involved in the event)
 
+      - name: last_player_role_team
+        description: The home / away status of the player's team from the previous (most recent) play
+
       - name: last_play_event_type
         description: Short description of the previous play's event type
 

--- a/models/staging/stg_nhl__live_plays.yml
+++ b/models/staging/stg_nhl__live_plays.yml
@@ -67,10 +67,10 @@ models:
         description: If the play in question was a penalty, this column will return the number of minutes the penalty was assessed for, else null
 
       - name: play_x_coordinate
-        description: The x-coordinate of where the event took place on the ice
+        description: The x-coordinate of where the event took place on the ice, between -100 and 100
 
       - name: play_y_coordinate
-        description: The y-coordinate of where the event took place on the ice
+        description: The y-coordinate of where the event took place on the ice, between -42.5 and 42.5
 
       - name: play_period
         description: The period in which the event occured (e.g. 3)

--- a/models/staging/stg_nhl__live_plays.yml
+++ b/models/staging/stg_nhl__live_plays.yml
@@ -48,17 +48,29 @@ models:
       - name: player_role_team
         description: The home / away status of the player's team
 
+      - name: event_code
+        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+
       - name: event_type
         description: Short description of the event type
 
-      - name: event_code
-        description: Event code that is unique at the game-event level (e.g. PHI8, PHI10)
+      - name: event_secondary_type
+        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
 
       - name: event_description
         description: Long description of the event (repeated for all the player's involved in the event)
 
-      - name: event_secondary_type
-        description: If the event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+      - name: last_play_event_type
+        description: Short description of the previous play's event type
+
+      - name: last_play_event_secondary_type
+        description: If the previous play's event_type can be further broken down, this field provides a sub-type, else null (e.g. TIP-IN, WRIST SHOT (shot-types), ROUGHING (penalty-types), etc.)
+
+      - name: last_play_event_description
+        description: Long description of the previous play's event (repeated for all the player's involved in the event)
+
+      - name: last_play_period
+        description: The period in which the previous play's event occured (e.g. 3)
 
       - name: penalty_severity
         description: If the play in question was a penalty, this column will describe its severity (e.g. MINOR, MAJOR), else null

--- a/models/staging/stg_nhl__live_plays.yml
+++ b/models/staging/stg_nhl__live_plays.yml
@@ -185,3 +185,30 @@ models:
 
       - name: game_state_lag
         description: The previous state of scoreboard prior to the play in question (e.g. "Tie", "Close" (1 goal difference), "Buffer" (2 goal difference), "Comfortable" (3 goal difference), "Blowout" (4 goal difference))
+
+      - name: last_shot_event_idx
+        description: Looks back to the last (previous) shot, returns the event sequence (e.g. 1 = first event, 2 = second event)
+
+      - name: last_shot_team_id
+        description: Looks back to the last (previous) shot, returns the team_id for the shoot
+
+      - name: last_shot_period
+        description: Looks back to the last (previous) shot, returns the period
+
+      - name: last_shot_total_seconds_elapsed
+        description: Looks back to the last (previous) shot, returns the total seconds elapsed
+
+      - name: last_shot_event_type
+        description: Looks back to the last (previous) shot, returns the event type (e.g. 'GOAL', 'MISSED_SHOT', 'SHOT', 'GOAL')
+
+      - name: last_shot_event_secondary_type
+        description: Looks back to the last (previous) shot, returns the event_secondary_type (e.g. basically, shot type)
+
+      - name: last_shot_x_coordinate
+        description: Looks back to the last (previous) shot, returns the x_coordinate
+
+      - name: last_shot_y_coordinate
+        description: Looks back to the last (previous) shot, returns the y_coordinate
+
+      - name: last_shot_saved_shot_ind
+        description: Looks back to the last (previous) shot, returns a '1' if the shot was taken by same team, in the same period, and was on target but did not result in a goal

--- a/models/staging/stg_nhl__live_plays_location.sql
+++ b/models/staging/stg_nhl__live_plays_location.sql
@@ -1,0 +1,100 @@
+-- #cte: depending on which end the team is shooting on, adjust the x and y play coordinates so that all plays are going towards the same end (all shots towards right end)
+with adj_coordinates as (
+  select
+    plays.stg_nhl__live_plays_id as play_id
+    , plays.game_id
+    , plays.event_id
+    , plays.player_id
+    , plays.team_id
+    , plays.event_idx
+    , schedule.game_type
+    , plays.play_period
+    , plays.event_type
+    , lower(plays.player_role_team) as player_role_team
+    , schedule.home_period1_shooting
+    , cast(plays.play_x_coordinate as float64) as play_x_coordinate
+    , cast(plays.play_y_coordinate as float64) as play_y_coordinate
+    -- Flip the x-y coords based on where the player's team was shooting in the first period of the game (reminder that when mod(x, 2) = 0 then odd number, but when > 0 then  even number)
+      , case
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64) * -1
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64) * -1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64) * -1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64) * -1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)
+        end as adj_play_x_coordinate
+      , case
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64) * -1
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)
+          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64) * -1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64) * -1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64) * -1
+          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)
+        end as adj_play_y_coordinate
+  from {{ ref('stg_nhl__live_plays') }} as plays
+  left join {{ ref('d_schedule') }} as schedule on schedule.game_id = plays.game_id
+
+)
+
+select
+    /* Primary Key */
+    play_id
+    /* Identifiers */
+    , game_id
+    , event_id
+    , player_id
+    , team_id
+    , game_type
+    , event_idx
+    /* Properties */
+    , play_period
+    , event_type
+    , player_role_team
+    , home_period1_shooting
+    , play_x_coordinate
+    , play_y_coordinate
+    , adj_play_x_coordinate
+    , adj_play_y_coordinate
+-- Rink distance from goal (shooting)... hypotenuse = sqrt( (x2-x1)^2 + (y2-y1)^2 )... where y1 = 0 and x1 = 89
+  , round(sqrt(power((89 - adj_play_x_coordinate), 2) + power(0 - adj_play_y_coordinate, 2)), 2) as play_distance
+  -- Rink angle from goal (shooting)... angle = tan^-1( (y2-y1) / (x2-x1) )... where y1 = 0 and x1 = 89
+  , case
+      when adj_play_x_coordinate = 89 then 0
+      else round(atan( ((adj_play_y_coordinate) / (89 - adj_play_x_coordinate)) ) * (180 / (acos(-1))), 2)
+      end as play_angle
+-- Rink zones
+  , case
+      when adj_play_y_coordinate < 0 then 'left'
+      when adj_play_y_coordinate > 0 then 'right'
+      when adj_play_y_coordinate = 0 then 'center'
+      else 'missing'
+    end as rink_side
+  , case
+      when adj_play_x_coordinate between -25 and 25 then 'neutral_zone'
+      when adj_play_x_coordinate between -100 and -25 then 'defensive_zone'
+      else 'offensive_zone'
+    end as zone_type
+  , case
+      when adj_play_x_coordinate between -25 and 25 then 'neutral_zone'
+      when adj_play_x_coordinate between -100 and -25 then 'defensive_zone'
+      when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between -42.5 and -7) then 'r_point'
+      when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between -7 and 7) then 'c_point'
+      when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between 7 and 42.5) then 'l_point'
+      when (adj_play_x_coordinate between 54 and 69) and (adj_play_y_coordinate between -42.5 and -22) then 'r_1_high'
+      when (adj_play_x_coordinate between 54 and 69) and (adj_play_y_coordinate between -22 and -7) then 'r_2_high'
+      when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between -7 and 7) then 'high_slot'
+      when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between 7 and 22) then 'l_2_high'
+      when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between 22 and 42.5) then 'l_1_high'
+      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -42.5 and -22) then 'r_1_low'
+      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -22 and -7) then 'r_2_low'
+      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -7 and 7) then 'low_slot'
+      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between 7 and 22) then 'l_2_low'
+      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between 22 and 42.5) then 'l_1_low'
+      when (adj_play_x_coordinate between 89 and 100) then 'down_low'
+    end as zone
+
+from adj_coordinates

--- a/models/staging/stg_nhl__live_plays_location.sql
+++ b/models/staging/stg_nhl__live_plays_location.sql
@@ -1,42 +1,42 @@
 -- #cte: depending on which end the team is shooting on, adjust the x and y play coordinates so that all plays are going towards the same end (all shots towards right end)
 with adj_coordinates as (
-  select
-    plays.stg_nhl__live_plays_id as play_id
-    , plays.game_id
-    , plays.event_id
-    , plays.player_id
-    , plays.team_id
-    , plays.event_idx
-    , schedule.game_type
-    , plays.play_period
-    , plays.event_type
-    , lower(plays.player_role_team) as player_role_team
-    , schedule.home_period1_shooting
-    , cast(plays.play_x_coordinate as float64) as play_x_coordinate
-    , cast(plays.play_y_coordinate as float64) as play_y_coordinate
-    -- Flip the x-y coords based on where the player's team was shooting in the first period of the game (reminder that when mod(x, 2) = 0 then odd number, but when > 0 then  even number)
-      , case
-          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64) * -1
-          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)
-          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)
-          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64) * -1
-          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)
-          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64) * -1
-          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64) * -1
-          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)
+    select
+        plays.stg_nhl__live_plays_id as play_id
+        , plays.game_id
+        , plays.event_id
+        , plays.player_id
+        , plays.team_id
+        , plays.event_idx
+        , schedule.game_type
+        , plays.play_period
+        , plays.event_type
+        , lower(plays.player_role_team) as player_role_team
+        , schedule.home_period1_shooting
+        , cast(plays.play_x_coordinate as float64) as play_x_coordinate
+        , cast(plays.play_y_coordinate as float64) as play_y_coordinate
+        -- Flip the x-y coords based on where the player's team was shooting in the first period of the game (reminder that when mod(x, 2) = 0 then odd number, but when > 0 then  even number)
+        , case
+            when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64) * -1
+            when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)
+            when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)
+            when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64) * -1
+            when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64)
+            when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64) * -1
+            when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_x_coordinate as float64) * -1
+            when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_x_coordinate as float64)
         end as adj_play_x_coordinate
-      , case
-          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64) * -1
-          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)
-          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)
-          when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64) * -1
-          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)
-          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64) * -1
-          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64) * -1
-          when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)
+        , case
+            when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64) * -1
+            when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)
+            when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)
+            when lower(plays.player_role_team) = 'home' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64) * -1
+            when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64)
+            when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'left' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64) * -1
+            when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) > 0 then cast(plays.play_y_coordinate as float64) * -1
+            when lower(plays.player_role_team) = 'away' and schedule.home_period1_shooting = 'right' and mod(plays.play_period, 2) = 0 then cast(plays.play_y_coordinate as float64)
         end as adj_play_y_coordinate
-  from {{ ref('stg_nhl__live_plays') }} as plays
-  left join {{ ref('d_schedule') }} as schedule on schedule.game_id = plays.game_id
+    from {{ ref('stg_nhl__live_plays') }} as plays
+    left join {{ ref('d_schedule') }} as schedule on schedule.game_id = plays.game_id
 
 )
 
@@ -59,42 +59,42 @@ select
     , play_y_coordinate
     , adj_play_x_coordinate
     , adj_play_y_coordinate
--- Rink distance from goal (shooting)... hypotenuse = sqrt( (x2-x1)^2 + (y2-y1)^2 )... where y1 = 0 and x1 = 89
-  , round(sqrt(power((89 - adj_play_x_coordinate), 2) + power(0 - adj_play_y_coordinate, 2)), 2) as play_distance
-  -- Rink angle from goal (shooting)... angle = tan^-1( (y2-y1) / (x2-x1) )... where y1 = 0 and x1 = 89
-  , case
-      when adj_play_x_coordinate = 89 then 0
-      else round(atan( ((adj_play_y_coordinate) / (89 - adj_play_x_coordinate)) ) * (180 / (acos(-1))), 2)
-      end as play_angle
--- Rink zones
-  , case
-      when adj_play_y_coordinate < 0 then 'left'
-      when adj_play_y_coordinate > 0 then 'right'
-      when adj_play_y_coordinate = 0 then 'center'
-      else 'missing'
+    -- Rink distance from goal (shooting)... hypotenuse = sqrt( (x2-x1)^2 + (y2-y1)^2 )... where y1 = 0 and x1 = 89
+    , round(sqrt(power((89 - adj_play_x_coordinate), 2) + power(0 - adj_play_y_coordinate, 2)), 2) as play_distance
+    -- Rink angle from goal (shooting)... angle = tan^-1( (y2-y1) / (x2-x1) )... where y1 = 0 and x1 = 89
+    , case
+        when adj_play_x_coordinate = 89 then 0
+        else round(atan( ((adj_play_y_coordinate) / (89 - adj_play_x_coordinate)) ) * (180 / (acos(-1))), 2)
+    end as play_angle
+    -- Rink zones
+    , case
+        when adj_play_y_coordinate < 0 then 'left'
+        when adj_play_y_coordinate > 0 then 'right'
+        when adj_play_y_coordinate = 0 then 'center'
+        else 'missing'
     end as rink_side
-  , case
-      when adj_play_x_coordinate between -25 and 25 then 'neutral_zone'
-      when adj_play_x_coordinate between -100 and -25 then 'defensive_zone'
-      else 'offensive_zone'
+    , case
+        when adj_play_x_coordinate between -25 and 25 then 'neutral_zone'
+        when adj_play_x_coordinate between -100 and -25 then 'defensive_zone'
+        else 'offensive_zone'
     end as zone_type
-  , case
-      when adj_play_x_coordinate between -25 and 25 then 'neutral_zone'
-      when adj_play_x_coordinate between -100 and -25 then 'defensive_zone'
-      when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between -42.5 and -7) then 'r_point'
-      when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between -7 and 7) then 'c_point'
-      when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between 7 and 42.5) then 'l_point'
-      when (adj_play_x_coordinate between 54 and 69) and (adj_play_y_coordinate between -42.5 and -22) then 'r_1_high'
-      when (adj_play_x_coordinate between 54 and 69) and (adj_play_y_coordinate between -22 and -7) then 'r_2_high'
-      when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between -7 and 7) then 'high_slot'
-      when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between 7 and 22) then 'l_2_high'
-      when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between 22 and 42.5) then 'l_1_high'
-      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -42.5 and -22) then 'r_1_low'
-      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -22 and -7) then 'r_2_low'
-      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -7 and 7) then 'low_slot'
-      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between 7 and 22) then 'l_2_low'
-      when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between 22 and 42.5) then 'l_1_low'
-      when (adj_play_x_coordinate between 89 and 100) then 'down_low'
+    , case
+        when adj_play_x_coordinate between -25 and 25 then 'neutral_zone'
+        when adj_play_x_coordinate between -100 and -25 then 'defensive_zone'
+        when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between -42.5 and -7) then 'r_point'
+        when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between -7 and 7) then 'c_point'
+        when (adj_play_x_coordinate between 25 and 54) and (adj_play_y_coordinate between 7 and 42.5) then 'l_point'
+        when (adj_play_x_coordinate between 54 and 69) and (adj_play_y_coordinate between -42.5 and -22) then 'r_1_high'
+        when (adj_play_x_coordinate between 54 and 69) and (adj_play_y_coordinate between -22 and -7) then 'r_2_high'
+        when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between -7 and 7) then 'high_slot'
+        when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between 7 and 22) then 'l_2_high'
+        when (adj_play_x_coordinate between 52 and 69) and (adj_play_y_coordinate between 22 and 42.5) then 'l_1_high'
+        when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -42.5 and -22) then 'r_1_low'
+        when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -22 and -7) then 'r_2_low'
+        when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between -7 and 7) then 'low_slot'
+        when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between 7 and 22) then 'l_2_low'
+        when (adj_play_x_coordinate between 69 and 89) and (adj_play_y_coordinate between 22 and 42.5) then 'l_1_low'
+        when (adj_play_x_coordinate between 89 and 100) then 'down_low'
     end as zone
 
 from adj_coordinates

--- a/models/staging/stg_nhl__live_plays_location.yml
+++ b/models/staging/stg_nhl__live_plays_location.yml
@@ -1,0 +1,68 @@
+version: 2
+
+models:
+  - name: stg_nhl__live_plays_location
+    description: Enahancing Staged NHL event level data from the NHL-API (player-play level) with x & y coordinate (location) mappings relative to the opposing goal
+    columns:
+      # Primary Key
+      - name: play_id
+        description: Unique surrogate key for a player's event-level activity in an NHL game (game_id + team_id + player_id + event_id)
+        tests:
+          - unique
+          - not_null
+
+      # Identifiers
+      - name: game_id
+        description: |
+          Foreign key that maps to an NHL game ID
+          {{ doc("game_id_description") }}
+
+      - name: event_id
+        description: Foreign key that maps to a distinct event ID
+
+      - name: player_id
+        description: Foreign key that maps to an NHL player ID
+
+      - name: team_id
+        description: Foreign key that maps to an NHL team ID
+
+      # Properties
+      - name: event_type
+        description: Short description of the event type
+
+      - name: event_idx
+        description: Foreign key that maps to the sequence of the event relative to that game, in ascending order (e.g. 1 = first event, 2 - second event)
+
+      - name: player_role_team
+        description: The role of the player in context to the event (e.g. Hitter, Hitee, Shooter, Winner, Loser, etc.)
+
+      - name: home_period1_shooting
+        description: The direction that the home team is shooting towards in period 1 ('left', 'right', 'missing')
+
+      - name: play_x_coordinate
+        description: The x-coordinate of where the event took place on the ice (converted to type float64)
+
+      - name: play_y_coordinate
+        description: The y-coordinate of where the event took place on the ice (converted to type float64)
+
+      - name: adj_play_x_coordinate
+        description: Adjusting the axis of plane of the play's x-coordinate based on where the oppsosing team's goalie net is as this is where they will be shooting towards
+
+      - name: adj_play_y_coordinate
+        description: Adjusting the axis of plane of the play's y-coordinate based on where the oppsosing team's goalie net is as this is where they will be shooting towards
+
+      - name: play_distance
+        description: Distance from the opposing goal, calculated by making a right angle with the play's [x,y] and the net [89,0], and finding the hypotenuse with the formula c = sqrt(a^2 + b^2)
+
+      - name: play_angle
+        description: Angle from the play's [x,y] coordinates to the opposing team's net [89,0]
+
+      - name: rink_side
+        description: The side of the rink based on the y-coordinate (e.g. "left" means that the team is on the left side of the rink)
+
+      - name: zone_type
+        description: Classifying each of the zones by its type, based on the x-coordinate (e.g. "offensive_zone")
+
+      - name: zone
+        description: The the area of the ice, determined by combining the x & y coordinates (e.g. "r_1_high")
+

--- a/models/staging/stg_nhl__rink_shooting.sql
+++ b/models/staging/stg_nhl__rink_shooting.sql
@@ -6,17 +6,17 @@
 with p1p3_plays_shots_home as (
     select
         plays.stg_nhl__live_plays_id as play_id
-    , plays.game_id
-    , schedule.game_type
-    , schedule.game_type_description
-    , plays.play_period
-    , plays.team_id
-    , plays.event_id
-    , plays.event_type
-    , teams.full_name as team_full_name
-    , plays.event_description
-    , plays.play_x_coordinate
-    , plays.play_y_coordinate
+        , plays.game_id
+        , schedule.game_type
+        , schedule.game_type_description
+        , plays.play_period
+        , plays.team_id
+        , plays.event_id
+        , plays.event_type
+        , teams.full_name as team_full_name
+        , plays.event_description
+        , plays.play_x_coordinate
+        , plays.play_y_coordinate
     from
         {{ ref('stg_nhl__live_plays') }} as plays
     inner join {{ref('stg_nhl__teams') }} as teams on teams.team_id = plays.team_id
@@ -34,14 +34,14 @@ with p1p3_plays_shots_home as (
 , p1_team_game_shots_home as (
     select
         ps.game_id
-    , ps.game_type
-    , ps.game_type_description
-    , ps.team_id
-    , ps.team_full_name
-    , ps.play_period
-    , count(1) as p1_shots
-    , sum(case when cast(ps.play_x_coordinate as float64) > 0 then 1 else 0 end) as p1_shots_right
-    , sum(case when cast(ps.play_x_coordinate as float64) < 0 then 1 else 0 end) as p1_shots_left
+        , ps.game_type
+        , ps.game_type_description
+        , ps.team_id
+        , ps.team_full_name
+        , ps.play_period
+        , count(1) as p1_shots
+        , sum(case when cast(ps.play_x_coordinate as float64) > 0 then 1 else 0 end) as p1_shots_right
+        , sum(case when cast(ps.play_x_coordinate as float64) < 0 then 1 else 0 end) as p1_shots_left
     from
         p1p3_plays_shots_home as ps
     where 1 = 1
@@ -53,14 +53,14 @@ with p1p3_plays_shots_home as (
 , p3_team_game_shots_home as (
     select
         ps.game_id
-    , ps.game_type
-    , ps.game_type_description
-    , ps.team_id
-    , ps.team_full_name
-    , ps.play_period
-    , count(1) as p3_shots
-    , sum(case when cast(ps.play_x_coordinate as float64) > 0 then 1 else 0 end) as p3_shots_right
-    , sum(case when cast(ps.play_x_coordinate as float64) < 0 then 1 else 0 end) as p3_shots_left
+        , ps.game_type
+        , ps.game_type_description
+        , ps.team_id
+        , ps.team_full_name
+        , ps.play_period
+        , count(1) as p3_shots
+        , sum(case when cast(ps.play_x_coordinate as float64) > 0 then 1 else 0 end) as p3_shots_right
+        , sum(case when cast(ps.play_x_coordinate as float64) < 0 then 1 else 0 end) as p3_shots_left
     from
         p1p3_plays_shots_home as ps
     where 1 = 1

--- a/models/staging/stg_nhl__rink_shooting.sql
+++ b/models/staging/stg_nhl__rink_shooting.sql
@@ -19,8 +19,8 @@ with p1p3_plays_shots_home as (
         , plays.play_y_coordinate
     from
         {{ ref('stg_nhl__live_plays') }} as plays
-    inner join {{ref('stg_nhl__teams') }} as teams on teams.team_id = plays.team_id
-    inner join {{ref('stg_nhl__schedule') }} as schedule on schedule.game_id = plays.game_id
+    inner join {{ ref('stg_nhl__teams') }} as teams on teams.team_id = plays.team_id
+    inner join {{ ref('stg_nhl__schedule') }} as schedule on schedule.game_id = plays.game_id
     where 1 = 1
         and (plays.play_period = 1 or plays.play_period = 3)
         and lower(plays.event_type) in ('goal', 'missed_shot', 'shot')

--- a/models/staging/stg_nhl__rink_shooting.sql
+++ b/models/staging/stg_nhl__rink_shooting.sql
@@ -74,21 +74,21 @@ select
     , p1.team_id
     , p1.game_type_description
     , p1.team_full_name
-    , p1_shots
-    , p1_shots_left
-    , p1_shots_right
-    , p3_shots
-    , p3_shots_left
-    , p3_shots_right
+    , p1.p1_shots
+    , p1.p1_shots_left
+    , p1.p1_shots_right
+    , p3.p3_shots
+    , p3.p3_shots_left
+    , p3.p3_shots_right
     -- in case period 1 is not enough to determine a shooting side, then bring in period 3 as well
     , case
-        when (p1_shots_right) + (p1_shots_left) = 0 then 'missing'
-        when p1_shots_right > p1_shots_left then 'right'
-        when p1_shots_right < p1_shots_left then 'left'
-        when (p1_shots_right + p3_shots_right) > (p1_shots_left + p3_shots_left) then 'right'
-        when (p1_shots_right + p3_shots_right) < (p1_shots_left + p3_shots_left) then 'left'
+        when (p1.p1_shots_right) + (p1.p1_shots_left) = 0 then 'missing'
+        when p1.p1_shots_right > p1.p1_shots_left then 'right'
+        when p1.p1_shots_right < p1.p1_shots_left then 'left'
+        when (p1.p1_shots_right + p3.p3_shots_right) > (p1.p1_shots_left + p3.p3_shots_left) then 'right'
+        when (p1.p1_shots_right + p3.p3_shots_right) < (p1.p1_shots_left + p3.p3_shots_left) then 'left'
     end as p1_shooting_location
 from
     p1_team_game_shots_home as p1
 left join p3_team_game_shots_home as p3 on p3.game_id = p1.game_id and p3.team_id = p1.team_id
-order by game_id
+order by p1.game_id

--- a/models/staging/stg_nhl__rink_shooting.sql
+++ b/models/staging/stg_nhl__rink_shooting.sql
@@ -1,0 +1,94 @@
+
+-- Goal: create a mapping table that we can join to with game_id & period & team from play-by-play data to know how to interpret the x-y coords
+-- Method: based on the assumptions that the majority of shots will come close to the net, classify the area of the ice with the most shots as the "shooting end", to then make axes adjustments to
+
+-- #cte1: pull all home team shots in the the first and third periods
+with p1p3_plays_shots_home as (
+    select
+        plays.stg_nhl__live_plays_id as play_id
+    , plays.game_id
+    , schedule.game_type
+    , schedule.game_type_description
+    , plays.play_period
+    , plays.team_id
+    , plays.event_id
+    , plays.event_type
+    , teams.full_name as team_full_name
+    , plays.event_description
+    , plays.play_x_coordinate
+    , plays.play_y_coordinate
+    from
+        {{ ref('stg_nhl__live_plays') }} as plays
+    inner join {{ref('stg_nhl__teams') }} as teams on teams.team_id = plays.team_id
+    inner join {{ref('stg_nhl__schedule') }} as schedule on schedule.game_id = plays.game_id
+    where 1 = 1
+        and (plays.play_period = 1 or plays.play_period = 3)
+        and lower(plays.event_type) in ('goal', 'missed_shot', 'shot')
+        and lower(plays.player_role_team) = 'home'
+        and lower(plays.player_role) in ('shooter', 'scorer')
+    order by
+        plays.game_id desc
+)
+
+-- #cte2: summarize shot at the game & team level for period 1
+, p1_team_game_shots_home as (
+    select
+        ps.game_id
+    , ps.game_type
+    , ps.game_type_description
+    , ps.team_id
+    , ps.team_full_name
+    , ps.play_period
+    , count(1) as p1_shots
+    , sum(case when cast(ps.play_x_coordinate as float64) > 0 then 1 else 0 end) as p1_shots_right
+    , sum(case when cast(ps.play_x_coordinate as float64) < 0 then 1 else 0 end) as p1_shots_left
+    from
+        p1p3_plays_shots_home as ps
+    where 1 = 1
+        and play_period = 1
+    group by 1, 2, 3, 4, 5, 6
+)
+
+-- #cte3: summarize shot at the game & team level for period 1
+, p3_team_game_shots_home as (
+    select
+        ps.game_id
+    , ps.game_type
+    , ps.game_type_description
+    , ps.team_id
+    , ps.team_full_name
+    , ps.play_period
+    , count(1) as p3_shots
+    , sum(case when cast(ps.play_x_coordinate as float64) > 0 then 1 else 0 end) as p3_shots_right
+    , sum(case when cast(ps.play_x_coordinate as float64) < 0 then 1 else 0 end) as p3_shots_left
+    from
+        p1p3_plays_shots_home as ps
+    where 1 = 1
+        and play_period = 3
+    group by 1, 2, 3, 4, 5, 6
+)
+
+--#return: period 1 shooting location for the home team by game_id
+select
+    p1.game_id
+    , p1.team_id
+    , p1.game_type_description
+    , p1.team_full_name
+    , p1_shots
+    , p1_shots_left
+    , p1_shots_right
+    , p3_shots
+    , p3_shots_left
+    , p3_shots_right
+    -- in case period 1 is not enough to determine a shooting side, then bring in period 3 as well
+    , case
+        when (p1_shots_right) + (p1_shots_left) = 0 then 'missing'
+        when p1_shots_right > p1_shots_left then 'right'
+        when p1_shots_right < p1_shots_left then 'left'
+        when (p1_shots_right + p3_shots_right) > (p1_shots_left + p3_shots_left) then 'right'
+        when (p1_shots_right + p3_shots_right) < (p1_shots_left + p3_shots_left) then 'left'
+    end as p1_shooting_location
+from
+    p1_team_game_shots_home as p1
+left join p3_team_game_shots_home as p3 on p3.game_id = p1.game_id and p3.team_id = p1.team_id
+order by game_id

--- a/models/staging/stg_nhl__rink_shooting.yml
+++ b/models/staging/stg_nhl__rink_shooting.yml
@@ -1,0 +1,43 @@
+version: 2
+
+models:
+  - name: stg_nhl__rink_shooting
+    description: Staged NHL game-team level data to determine which net the home team is shooting towards in period 1
+    columns:
+      # Primary Key
+      - name: game_id
+        description: Unique surrogate key from a combination of the NHL player ID, team ID and the season ID
+        tests:
+          - unique
+          - not_null
+
+      - name: team_id
+        description: Foreign key that maps to the NHL team ID that the NHL player played for in a given season
+
+      # Properties
+      - name: game_type_description
+        description: Description for the type of game played, enhancing game_type (e.g. Pre-season, Regular, Playoffs, All-star)
+
+      - name: team_full_name
+        description: Full name of the NHL team (e.g. Vancouver Canucks)
+
+      - name: p1_shots
+        description: Number of shots taken by the home team in period 1
+
+      - name: p1_shots_left
+        description: Number of shots taken by the home team in period 1 that were to the left of the rink based on the x_coordinate being negative
+
+      - name: p1_shots_right
+        description: Number of shots taken by the home team in period 1 that were to the right of the rink based on the x_coordinate neing positive
+
+      - name: p3_shots
+        description: Number of shots taken by the home team in period 3
+
+      - name: p3_shots_left
+        description: Number of shots taken by the home team in period 3 that were to the left of the rink based on the x_coordinate being negative
+
+      - name: p3_shots_right
+        description: Number of shots taken by the home team in period 3 that were to the right of the rink based on the x_coordinate neing positive
+
+      - name: p1_shooting_location
+        description: The direction that the home team is shooting towards in period 1 ('left', 'right', 'missing')

--- a/models/utils/dates.sql
+++ b/models/utils/dates.sql
@@ -1,5 +1,5 @@
 with date_spine as (
-    {{ dbt_utils.date_spine(
+{{ dbt_utils.date_spine(
         datepart="day",
         start_date="cast('2010-01-01' as date)",
         end_date="cast('2030-01-01' as date)"


### PR DESCRIPTION
# Overview
- This PR is all about getting context on the x and y coordinates found in the play-by-play datasets. Specifically, learning which way each player is shooting towards, the play's distance to the opposing team's goal, and the play's angle to the opposing team's goal
- Resolves #57 

# Changes
- Staging (views) table changes (2 new views):
  - `stg_nhl__rink_shooting`:  game-team-period level dataset that provides which side of the rink the home team was shooting in period 1
  - `stg_nhl__live_plays_location`: play-by-play dataset enhanced with the distance to the goal, angle to goal, and different zone classifications like area, type, and zone
- Intermediate (table) changes (changes to `d_schedule`):
  - I created some features into `d_schedule` from `stg_nhl__rink_shooting` to figure out where the team is shooting:
    - home_period1_shooting
    - home_period2_shooting
    - home_period3_shooting
    - away_period1_shooting
    - away_period2_shooting
    - away_period3_shooting

# Other notes
* Also added `last_player_role_team` to `live_plays` and `f_plays` since this would save a join later on when building the XG model

# Checks
- [x] All models ran successfully
- [x] Changes to models are reflected in the schema.yml
Pick one:
- [x] No test failures OR
- [ ] No new test failures, and there is a plan in place to address existing ones
